### PR TITLE
Add INTX_TESTING OPTION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,13 @@ HunterGate(
 
 project(intx)
 
+option(INTX_TESTING "Build IntX with tests" ON)
 # FIXME: Add back -Wconversion, test with clang.
 add_compile_options(-Werror -Wall -Wextra)
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
 
 add_subdirectory(libs/intx)
 
-add_subdirectory(tests)
+if(INTX_TESTING)
+	add_subdirectory(tests)
+endif()


### PR DESCRIPTION
CMake option to enable or disable building tests in IntX. On by default.