### PR TITLE
int128: Define uint128 as the uint<128> specialization

### DIFF
--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -15,26 +15,34 @@
 
 namespace intx
 {
-struct uint128
+template <unsigned N>
+struct uint;
+
+/// The 128-bit unsigned integer.
+///
+/// This type is defined as a specialization of uint<> to easier integration with full intx package,
+/// however, uint128 may be used indepedently.
+template<>
+struct uint<128>
 {
     uint64_t lo = 0;
     uint64_t hi = 0;
 
-    constexpr uint128() noexcept = default;
+    constexpr uint() noexcept = default;
 
-    constexpr uint128(uint64_t hi, uint64_t lo) noexcept : lo{lo}, hi{hi} {}
+    constexpr uint(uint64_t hi, uint64_t lo) noexcept : lo{lo}, hi{hi} {}
 
     template <typename T,
         typename = typename std::enable_if<std::is_convertible<T, uint64_t>::value>::type>
-    constexpr uint128(T x) noexcept : lo(x)  // NOLINT
+    constexpr uint(T x) noexcept : lo(x)  // NOLINT
     {}
 
     template <typename T, typename std::enable_if<std::is_integral<T>::value>::type>
-    constexpr explicit uint128(T x) noexcept : lo(x)
+    constexpr explicit uint(T x) noexcept : lo(x)
     {}
 
 #ifdef __SIZEOF_INT128__
-    constexpr uint128(unsigned __int128 x) noexcept  // NOLINT
+    constexpr uint(unsigned __int128 x) noexcept  // NOLINT
       : lo{uint64_t(x)}, hi{uint64_t(x >> 64)}
     {}
 
@@ -53,6 +61,8 @@ struct uint128
         return static_cast<Int>(lo);
     }
 };
+
+using uint128 = uint<128>;
 
 
 /// Linear arithmetic operators.

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -25,14 +25,9 @@ struct uint
     using word_type = uint64_t;
 
     /// The 2x smaller type.
-    ///
-    /// In the generic case of uint<N> the half type is just uint<N / 2>,
-    /// but we have to handle the uint<256> case differently by using
-    /// the external uint128 type.
-    using half_type = std::conditional_t<N == 256, uint128, uint<N / 2>>;
+    using half_type = uint<N / 2>;
 
     static constexpr auto num_words = N / 8 / sizeof(word_type);
-
 
     half_type lo = 0;
     half_type hi = 0;


### PR DESCRIPTION
This allows easier integration with full intx package.