### PR TITLE
Division improvements

### DIFF
--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -771,7 +771,7 @@ inline std::string to_string(uint<N> x, int base = 10)
     while (x != 0)
     {
         // TODO: Use constexpr udivrem_1?
-        const auto res = udivrem(x, base);
+        const auto res = udivrem(x, uint<N>{base});
         const auto d = int(res.rem);
         const auto c = d < 10 ? '0' + d : 'a' + d - 10;
         s.push_back(char(c));

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -730,8 +730,8 @@ inline typename std::enable_if<sizeof(Word) < sizeof(Int), unsigned>::type count
     return h != 0 ? h + (num_words / 2) : l;
 }
 
-div_result<uint256> udivrem(const uint256& u, const uint256& v) noexcept;
-div_result<uint512> udivrem(const uint512& x, const uint512& y) noexcept;
+template <unsigned N>
+div_result<uint<N>> udivrem(const uint<N>& u, const uint<N>& v) noexcept;
 
 template <unsigned N>
 constexpr div_result<uint<N>> sdivrem(const uint<N>& u, const uint<N>& v) noexcept

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -26,6 +26,7 @@ struct uint
     /// The 2x smaller type.
     using half_type = uint<N / 2>;
 
+    static constexpr auto num_bits = N;
     static constexpr auto num_words = N / 8 / sizeof(word_type);
 
     half_type lo = 0;

--- a/lib/intx/div.cpp
+++ b/lib/intx/div.cpp
@@ -20,7 +20,7 @@ union uint512_words64
     word_type& operator[](size_t index) { return words[index]; }
 };
 
-inline div_result<uint512> udivrem_by1(const normalized_div_args& na) noexcept
+inline div_result<uint512> udivrem_by1(const normalized_div_args<512>& na) noexcept
 {
     auto u = as_words(na.numerator);
     auto d = as_words(na.denominator)[0];
@@ -40,7 +40,7 @@ inline div_result<uint512> udivrem_by1(const normalized_div_args& na) noexcept
     return {q.number, x.rem >> na.shift};
 }
 
-inline div_result<uint512> udivrem_by2(const normalized_div_args& na) noexcept
+inline div_result<uint512> udivrem_by2(const normalized_div_args<512>& na) noexcept
 {
     auto u = as_words(na.numerator);
     auto dw = as_words(na.denominator);
@@ -144,7 +144,7 @@ void udivrem_knuth(uint64_t q[], uint64_t un[], int m, const uint64_t vn[], int 
     }
 }
 
-inline div_result<uint512> udivrem_knuth_wrapper(normalized_div_args& na) noexcept
+inline div_result<uint512> udivrem_knuth_wrapper(normalized_div_args<512>& na) noexcept
 {
     auto n = na.num_denominator_words;
     auto m = na.num_numerator_words;

--- a/lib/intx/div.cpp
+++ b/lib/intx/div.cpp
@@ -130,7 +130,6 @@ void udivrem_knuth(uint64_t q[], uint64_t un[], int m, const uint64_t vn[], int 
             // un[j+n] += k;
         }
 
-        // OPT: We can avoid allocating q, un can re used to store quotient.
         q[j] = qhat;  // Store quotient digit.
     }
 }

--- a/lib/intx/div.cpp
+++ b/lib/intx/div.cpp
@@ -22,7 +22,7 @@ union uint512_words64
 
 inline div_result<uint512> udivrem_by1(const normalized_div_args& na) noexcept
 {
-    auto d = na.denominator[0];
+    auto d = as_words(na.denominator)[0];
     auto v = reciprocal_2by1(d);
 
     auto q = uint512_words64{};
@@ -41,7 +41,8 @@ inline div_result<uint512> udivrem_by1(const normalized_div_args& na) noexcept
 
 inline div_result<uint512> udivrem_by2(const normalized_div_args& na) noexcept
 {
-    auto d = uint128{na.denominator[1], na.denominator[0]};
+    auto dw = as_words(na.denominator);
+    auto d = uint128{dw[1], dw[0]};
     auto v = reciprocal_3by2(d);
 
     auto q = uint512_words64{};
@@ -146,13 +147,12 @@ inline div_result<uint512> udivrem_knuth_wrapper(normalized_div_args& na) noexce
     auto n = na.num_denominator_words;
     auto m = na.num_numerator_words;
 
-    const auto& vn = na.denominator;
     auto& un = na.numerator;  // Will be modified.
 
     uint512 q;
     uint512_words64 r;
 
-    udivrem_knuth(as_words(q), &un[0], m, &vn[0], n);
+    udivrem_knuth(as_words(q), &un[0], m, as_words(na.denominator), n);
 
     for (int i = 0; i < n; ++i)
         r[i] = na.shift ? (un[i] >> na.shift) | (un[i + 1] << (64 - na.shift)) : un[i];

--- a/lib/intx/div.cpp
+++ b/lib/intx/div.cpp
@@ -8,18 +8,6 @@ namespace intx
 {
 namespace
 {
-union uint512_words64
-{
-    using word_type = uint64_t;
-
-    const uint512 number;
-    word_type words[uint512::num_words];
-
-    constexpr explicit uint512_words64(uint512 x = {}) noexcept : number{x} {}
-
-    word_type& operator[](size_t index) { return words[index]; }
-};
-
 /// Divides arbitrary long unsigned integer by 64-bit unsigned integer (1 word).
 /// @param u  The array of a normalized numerator words. It will contain the quotient after
 ///           execution.
@@ -149,13 +137,8 @@ void udivrem_knuth(uint64_t q[], uint64_t un[], int m, const uint64_t vn[], int 
 
 }  // namespace
 
-div_result<uint256> udivrem(const uint256& u, const uint256& v) noexcept
-{
-    auto x = udivrem(uint512{u}, uint512{v});
-    return {x.quot.lo, x.rem.lo};
-}
-
-div_result<uint512> udivrem(const uint512& u, const uint512& v) noexcept
+template <unsigned N>
+div_result<uint<N>> udivrem(const uint<N>& u, const uint<N>& v) noexcept
 {
     auto na = normalize(u, v);
 
@@ -181,8 +164,8 @@ div_result<uint512> udivrem(const uint512& u, const uint512& v) noexcept
 
     auto un = as_words(na.numerator);  // Will be modified.
 
-    uint512 q;
-    uint512 r;
+    uint<N> q;
+    uint<N> r;
     auto rw = as_words(r);
 
     udivrem_knuth(as_words(q), &un[0], m, as_words(na.denominator), n);
@@ -192,5 +175,8 @@ div_result<uint512> udivrem(const uint512& u, const uint512& v) noexcept
 
     return {q, r};
 }
+
+template div_result<uint256> udivrem(const uint256& u, const uint256& v) noexcept;
+template div_result<uint512> udivrem(const uint512& u, const uint512& v) noexcept;
 
 }  // namespace intx

--- a/lib/intx/div.hpp
+++ b/lib/intx/div.hpp
@@ -55,9 +55,9 @@ inline normalized_div_args<IntT::num_bits> normalize(
     }
     else
     {
-        un[num_words] = 0;
-        std::memcpy(un, u, sizeof(numerator));
-        std::memcpy(vn, v, sizeof(denominator));
+        na.numerator_ex = 0;
+        na.numerator = numerator;
+        na.denominator = denominator;
     }
 
     return na;

--- a/lib/intx/div.hpp
+++ b/lib/intx/div.hpp
@@ -12,10 +12,10 @@ struct normalized_div_args
 {
     using word_type = uint64_t;
 
+    uint<512> denominator;
     std::array<word_type, sizeof(uint512) / sizeof(word_type) + 1> numerator;
-    std::array<word_type, sizeof(uint512) / sizeof(word_type)> denominator;
-    int num_numerator_words;
     int num_denominator_words;
+    int num_numerator_words;
     int shift;
 };
 
@@ -28,7 +28,7 @@ inline normalized_div_args normalize(const uint512& numerator, const uint512& de
 
     normalized_div_args na;
     auto* un = &na.numerator[0];
-    auto* vn = &na.denominator[0];
+    auto* vn = as_words(na.denominator);
 
     auto& m = na.num_numerator_words;
     for (m = num_words; m > 0 && u[m - 1] == 0; --m)

--- a/lib/intx/div.hpp
+++ b/lib/intx/div.hpp
@@ -10,10 +10,9 @@ namespace intx
 {
 struct normalized_div_args
 {
-    using word_type = uint64_t;
-
     uint<512> denominator;
-    std::array<word_type, sizeof(uint512) / sizeof(word_type) + 1> numerator;
+    uint<512> numerator;
+    uint<512>::word_type numerator_ex;
     int num_denominator_words;
     int num_numerator_words;
     int shift;
@@ -21,13 +20,13 @@ struct normalized_div_args
 
 inline normalized_div_args normalize(const uint512& numerator, const uint512& denominator) noexcept
 {
-    static constexpr auto num_words = int{sizeof(uint512) / sizeof(normalized_div_args::word_type)};
+    static constexpr auto num_words = uint512::num_words;
 
     auto* u = as_words(numerator);
     auto* v = as_words(denominator);
 
     normalized_div_args na;
-    auto* un = &na.numerator[0];
+    auto* un = as_words(na.numerator);
     auto* vn = as_words(na.denominator);
 
     auto& m = na.num_numerator_words;

--- a/lib/intx/div.hpp
+++ b/lib/intx/div.hpp
@@ -8,24 +8,28 @@
 
 namespace intx
 {
+template <unsigned N>
 struct normalized_div_args
 {
-    uint<512> denominator;
-    uint<512> numerator;
-    uint<512>::word_type numerator_ex;
+    uint<N> denominator;
+    uint<N> numerator;
+    typename uint<N>::word_type numerator_ex;
     int num_denominator_words;
     int num_numerator_words;
     int shift;
 };
 
-inline normalized_div_args normalize(const uint512& numerator, const uint512& denominator) noexcept
+template <typename IntT>
+inline normalized_div_args<IntT::num_bits> normalize(
+    const IntT& numerator, const IntT& denominator) noexcept
 {
-    static constexpr auto num_words = uint512::num_words;
+    // FIXME: Make the implementation type independent
+    static constexpr auto num_words = IntT::num_words;
 
     auto* u = as_words(numerator);
     auto* v = as_words(denominator);
 
-    normalized_div_args na;
+    normalized_div_args<IntT::num_bits> na;
     auto* un = as_words(na.numerator);
     auto* vn = as_words(na.denominator);
 

--- a/test/benchmarks/bench_div.cpp
+++ b/test/benchmarks/bench_div.cpp
@@ -25,7 +25,7 @@ inline uint64_t udiv_by_reciprocal(uint64_t uu, uint64_t du) noexcept
 }
 
 
-template <decltype(normalize) NormalizeFn>
+template <decltype(normalize<uint512>) NormalizeFn>
 static void div_normalize(benchmark::State& state)
 {
     auto u = uint512{{48882153453, 100324254353}, {4343242153453, 1324254353}};

--- a/test/unittests/test_div.cpp
+++ b/test/unittests/test_div.cpp
@@ -17,9 +17,8 @@ TEST(div, normalize)
     EXPECT_EQ(na.shift, 63);
     EXPECT_EQ(na.num_denominator_words, 1);
     EXPECT_EQ(na.num_numerator_words, 0);
-    EXPECT_EQ(na.numerator[0], 0);
-    EXPECT_EQ(na.numerator[1], 0);
-    EXPECT_EQ(na.numerator[8], 0);
+    EXPECT_EQ(na.numerator, 0);
+    EXPECT_EQ(na.numerator_ex, 0);
     EXPECT_EQ(na.denominator, v << 63);
 
     u = uint512{1414, 1313};
@@ -28,11 +27,8 @@ TEST(div, normalize)
     EXPECT_EQ(na.shift, 60);
     EXPECT_EQ(na.num_denominator_words, 5);
     EXPECT_EQ(na.num_numerator_words, 5);
-    EXPECT_EQ(na.numerator[0], uint64_t{1313} << 60);
-    EXPECT_EQ(na.numerator[1], uint64_t{1313} >> (64 - 60));
-    EXPECT_EQ(na.numerator[2], 0);
-    EXPECT_EQ(na.numerator[4], uint64_t{1414} << 60);
-    EXPECT_EQ(na.numerator[na.num_numerator_words], uint64_t{1414} >> (64 - 60));
+    EXPECT_EQ(na.numerator, u << 60);
+    EXPECT_EQ(na.numerator_ex, 0);
     EXPECT_EQ(na.denominator, v << 60);
 
     u = uint512{3} << 510;
@@ -41,12 +37,8 @@ TEST(div, normalize)
     EXPECT_EQ(na.shift, 0);
     EXPECT_EQ(na.num_denominator_words, 3);
     EXPECT_EQ(na.num_numerator_words, 8);
-    EXPECT_EQ(na.numerator[0], 0);
-    EXPECT_EQ(na.numerator[1], 0);
-    EXPECT_EQ(na.numerator[2], 0);
-    EXPECT_EQ(na.numerator[4], 0);
-    EXPECT_EQ(na.numerator[7], uint64_t{3} << 62);
-    EXPECT_EQ(na.numerator[8], 0);
+    EXPECT_EQ(na.numerator, u);
+    EXPECT_EQ(na.numerator_ex, 0);
     EXPECT_EQ(na.denominator, v);
 
     u = uint512{7} << 509;
@@ -55,9 +47,8 @@ TEST(div, normalize)
     EXPECT_EQ(na.shift, 2);
     EXPECT_EQ(na.num_denominator_words, 3);
     EXPECT_EQ(na.num_numerator_words, 8);
-    EXPECT_EQ(na.numerator[6], 0);
-    EXPECT_EQ(na.numerator[7], uint64_t{1} << 63);
-    EXPECT_EQ(na.numerator[8], 3);
+    EXPECT_EQ(na.numerator, u << 2);
+    EXPECT_EQ(na.numerator_ex, 3);
     EXPECT_EQ(na.denominator, v << 2);
 }
 

--- a/test/unittests/test_div.cpp
+++ b/test/unittests/test_div.cpp
@@ -20,8 +20,7 @@ TEST(div, normalize)
     EXPECT_EQ(na.numerator[0], 0);
     EXPECT_EQ(na.numerator[1], 0);
     EXPECT_EQ(na.numerator[8], 0);
-    EXPECT_EQ(na.denominator[0], uint64_t{1} << 63);
-    EXPECT_EQ(na.denominator[1], 0);
+    EXPECT_EQ(na.denominator, v << 63);
 
     u = uint512{1414, 1313};
     v = uint512{12, 1212};
@@ -34,11 +33,7 @@ TEST(div, normalize)
     EXPECT_EQ(na.numerator[2], 0);
     EXPECT_EQ(na.numerator[4], uint64_t{1414} << 60);
     EXPECT_EQ(na.numerator[na.num_numerator_words], uint64_t{1414} >> (64 - 60));
-    EXPECT_EQ(na.denominator[0], uint64_t{1212} << 60);
-    EXPECT_EQ(na.denominator[1], uint64_t{1212} >> (64 - 60));
-    EXPECT_EQ(na.denominator[2], 0);
-    EXPECT_EQ(na.denominator[4], uint64_t{12} << 60);
-    EXPECT_EQ(na.denominator[5], 0);
+    EXPECT_EQ(na.denominator, v << 60);
 
     u = uint512{3} << 510;
     v = uint256{0xffffffffffffffff, 1};
@@ -52,10 +47,7 @@ TEST(div, normalize)
     EXPECT_EQ(na.numerator[4], 0);
     EXPECT_EQ(na.numerator[7], uint64_t{3} << 62);
     EXPECT_EQ(na.numerator[8], 0);
-    EXPECT_EQ(na.denominator[0], 1);
-    EXPECT_EQ(na.denominator[1], 0);
-    EXPECT_EQ(na.denominator[2], 0xffffffffffffffff);
-    EXPECT_EQ(na.denominator[3], 0);
+    EXPECT_EQ(na.denominator, v);
 
     u = uint512{7} << 509;
     v = uint256{0x3fffffffffffffff, 1};
@@ -66,10 +58,7 @@ TEST(div, normalize)
     EXPECT_EQ(na.numerator[6], 0);
     EXPECT_EQ(na.numerator[7], uint64_t{1} << 63);
     EXPECT_EQ(na.numerator[8], 3);
-    EXPECT_EQ(na.denominator[0], 4);
-    EXPECT_EQ(na.denominator[1], 0);
-    EXPECT_EQ(na.denominator[2], 0xfffffffffffffffc);
-    EXPECT_EQ(na.denominator[3], 0);
+    EXPECT_EQ(na.denominator, v << 2);
 }
 
 template <typename Int>


### PR DESCRIPTION
This makes 256-bit division ~40% faster and 512-bit division ~10% slower.
```
Benchmark                                   Time             CPU      Time Old      Time New       CPU Old       CPU New
------------------------------------------------------------------------------------------------------------------------
udiv<uint256, uint32_t, udivrem>         -0.4528         -0.4528         56945         31162         56945         31162
udiv<uint256, uint64_t, udivrem>         -0.3995         -0.3995         55146         33118         55145         33117
udiv<uint256, uint128, udivrem>          -0.4197         -0.4198         58186         33763         58186         33762
udiv<uint256, uint256, udivrem>          -0.0868         -0.0869         37118         33894         37117         33893
udiv<uint512, uint32_t, udivrem>         +0.0660         +0.0660         56905         60663         56905         60662
udiv<uint512, uint64_t, udivrem>         +0.0833         +0.0833         55982         60648         55982         60647
udiv<uint512, uint256, udivrem>          -0.0463         -0.0463         97535         93020         97533         93018
```