### PR TITLE
Rework and extend endian-specific conversion API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,34 @@ The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
 
-## [0.3.0] - 2019-06-20
-### Added
-- New `addmod()` and `mulmod()` procedures have been added for the `uint256` type 
-  ([#101](https://github.com/chfast/intx/pull/101)).
-### Changed
-- Pedantic compiler warnings have been fixed 
-  ([#98](https://github.com/chfast/intx/pull/98)).
-- Performance of the division algorithm increased up to 40% 
-  when dividing 256-bit values by 128-bit and 64-bit ones 
-  ([#99](https://github.com/chfast/intx/pull/99)).
+## [0.4.0] - unreleased
 
+### Added
+
+- Added the `as_bytes()` casting helper.
+  [[#106](https://github.com/chfast/intx/pull/106)]
+
+### Changed
+
+- The endian-specific API for converting intx types to/from bytes has been reworked.
+  [[#107](https://github.com/chfast/intx/pull/107)]
+
+
+## [0.3.0] - 2019-06-20
+
+### Added
+- New `addmod()` and `mulmod()` procedures have been added for the `uint256` type. 
+  [[#101](https://github.com/chfast/intx/pull/101)]
+
+### Changed
+- Pedantic compiler warnings have been fixed.
+  [[#98](https://github.com/chfast/intx/pull/98)]
+- Performance of the division algorithm increased up to 40% 
+  when dividing 256-bit values by 128-bit and 64-bit ones.
+  [[#99](https://github.com/chfast/intx/pull/99)]
+
+
+[0.4.0]: https://github.com/chfast/intx/compare/v0.3.0...master
 [0.3.0]: https://github.com/chfast/intx/releases/v0.2.0
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/

--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -28,6 +28,8 @@ struct uint;
 template <>
 struct uint<128>
 {
+    static constexpr unsigned num_bits = 128;
+
     uint64_t lo = 0;
     uint64_t hi = 0;
 

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -990,28 +990,28 @@ namespace be  // Conversions to/from BE bytes.
 {
 /// Loads an uint value from bytes of big-endian order.
 /// If the size of bytes is smaller than the result uint, the value is zero-extended.
-template <unsigned N, unsigned M>
-inline intx::uint<N> load(const uint8_t (&bytes)[M]) noexcept
+template <typename IntT, unsigned M>
+inline IntT load(const uint8_t (&bytes)[M]) noexcept
 {
-    static_assert(
-        M <= N / 8, "the size of source bytes must not exceed the size of the destination uint");
-    auto x = intx::uint<N>{};
-    std::memcpy(&as_bytes(x)[N / 8 - M], bytes, M);
+    static_assert(M <= IntT::num_bits / 8,
+        "the size of source bytes must not exceed the size of the destination uint");
+    auto x = IntT{};
+    std::memcpy(&as_bytes(x)[IntT::num_bits / 8 - M], bytes, M);
     return bswap(x);
 }
 
-template <unsigned N, typename T>
-inline intx::uint<N> load(const T& t) noexcept
+template <typename IntT, typename T>
+inline IntT load(const T& t) noexcept
 {
-    return load<N>(t.bytes);
+    return load<IntT>(t.bytes);
 }
 
 /// Loads an uint value from a buffer. The user must make sure
 /// that the provided buffer is big enough. Therefore marked "unsafe".
-template <unsigned N>
-inline intx::uint<N> uint_unsafe(const uint8_t* bytes) noexcept
+template <typename IntT>
+inline IntT unsafe_load(const uint8_t* bytes) noexcept
 {
-    auto x = intx::uint<N>{};
+    auto x = IntT{};
     std::memcpy(&x, bytes, sizeof(x));
     return bswap(x);
 }

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -970,17 +970,15 @@ constexpr uint512 operator"" _u512(const char* s) noexcept
 namespace le  // Conversions to/from LE bytes.
 {
 template <unsigned N>
-inline intx::uint<N> uint(const uint8_t bytes[sizeof(intx::uint<N>)]) noexcept
+inline intx::uint<N> uint(const uint8_t (&bytes)[N / 8]) noexcept
 {
     auto x = intx::uint<N>{};
     std::memcpy(&x, bytes, sizeof(x));
     return x;
 }
-constexpr auto uint256 = uint<256>;
-constexpr auto uint512 = uint<512>;
 
 template <unsigned N>
-inline void store(uint8_t* dst, const intx::uint<N>& x) noexcept
+inline void store(uint8_t (&dst)[N / 8], const intx::uint<N>& x) noexcept
 {
     std::memcpy(dst, &x, sizeof(x));
 }

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1006,16 +1006,6 @@ inline IntT load(const T& t) noexcept
     return load<IntT>(t.bytes);
 }
 
-/// Loads an uint value from a buffer. The user must make sure
-/// that the provided buffer is big enough. Therefore marked "unsafe".
-template <typename IntT>
-inline IntT unsafe_load(const uint8_t* bytes) noexcept
-{
-    auto x = IntT{};
-    std::memcpy(&x, bytes, sizeof(x));
-    return bswap(x);
-}
-
 /// Stores an uint value in a bytes array in big-endian order.
 template <unsigned N>
 inline void store(uint8_t (&dst)[N / 8], const intx::uint<N>& x) noexcept
@@ -1055,16 +1045,27 @@ inline T trunc(const intx::uint<N>& x) noexcept
     return r;
 }
 
+namespace unsafe
+{
+/// Loads an uint value from a buffer. The user must make sure
+/// that the provided buffer is big enough. Therefore marked "unsafe".
+template <typename IntT>
+inline IntT load(const uint8_t* bytes) noexcept
+{
+    auto x = IntT{};
+    std::memcpy(&x, bytes, sizeof(x));
+    return bswap(x);
+}
+
 /// Stores an uint value at the provided pointer in big-endian order. The user must make sure
 /// that the provided buffer is big enough to fit the value. Therefore marked "unsafe".
 template <unsigned N>
-inline void store_unsafe(uint8_t* dst, const intx::uint<N>& x) noexcept
+inline void store(uint8_t* dst, const intx::uint<N>& x) noexcept
 {
     const auto d = bswap(x);
     std::memcpy(dst, &d, sizeof(d));
 }
-
-
+}  // namespace unsafe
 
 }  // namespace be
 

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1000,10 +1000,11 @@ inline intx::uint<N> uint(const uint8_t bytes[sizeof(intx::uint<N>)]) noexcept
 constexpr auto uint256 = uint<256>;
 constexpr auto uint512 = uint<512>;
 
+/// Stores an uint value in a bytes array in big-endian order.
 template <unsigned N>
-inline void store(uint8_t* dst, const intx::uint<N>& x) noexcept
+inline void store(uint8_t (&dst)[N / 8], const intx::uint<N>& x) noexcept
 {
-    auto d = bswap(x);
+    const auto d = bswap(x);
     std::memcpy(dst, &d, sizeof(d));
 }
 

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -990,15 +990,17 @@ inline void store(uint8_t* dst, const intx::uint<N>& x) noexcept
 
 namespace be  // Conversions to/from BE bytes.
 {
-template <unsigned N>
-inline intx::uint<N> uint(const uint8_t bytes[sizeof(intx::uint<N>)]) noexcept
+/// Loads an uint value from bytes of big-endian order.
+/// If the size of bytes is smaller than the result uint, the value is zero-extended.
+template <unsigned N, unsigned M>
+inline intx::uint<N> uint(const uint8_t (&bytes)[M]) noexcept
 {
+    static_assert(
+        M <= N / 8, "the size of source bytes must not exceed the size of the destination uint");
     auto x = intx::uint<N>{};
-    std::memcpy(&x, bytes, sizeof(x));
+    std::memcpy(&as_bytes(x)[N / 8 - M], bytes, M);
     return bswap(x);
 }
-constexpr auto uint256 = uint<256>;
-constexpr auto uint512 = uint<512>;
 
 /// Stores an uint value in a bytes array in big-endian order.
 template <unsigned N>

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -991,7 +991,7 @@ namespace be  // Conversions to/from BE bytes.
 /// Loads an uint value from bytes of big-endian order.
 /// If the size of bytes is smaller than the result uint, the value is zero-extended.
 template <unsigned N, unsigned M>
-inline intx::uint<N> uint(const uint8_t (&bytes)[M]) noexcept
+inline intx::uint<N> load(const uint8_t (&bytes)[M]) noexcept
 {
     static_assert(
         M <= N / 8, "the size of source bytes must not exceed the size of the destination uint");
@@ -1001,9 +1001,9 @@ inline intx::uint<N> uint(const uint8_t (&bytes)[M]) noexcept
 }
 
 template <unsigned N, typename T>
-inline intx::uint<N> uint(const T& t) noexcept
+inline intx::uint<N> load(const T& t) noexcept
 {
-    return uint<N>(t.bytes);
+    return load<N>(t.bytes);
 }
 
 /// Loads an uint value from a buffer. The user must make sure

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1008,6 +1008,16 @@ inline void store(uint8_t (&dst)[N / 8], const intx::uint<N>& x) noexcept
     std::memcpy(dst, &d, sizeof(d));
 }
 
+/// Stores an uint value in .bytes field of type T. The .bytes must be an array of uint8_t
+/// of the size matching the size of uint.
+template <typename T, unsigned N>
+inline T store(const intx::uint<N>& x) noexcept
+{
+    T r{};
+    store(r.bytes, x);
+    return r;
+}
+
 /// Stores the truncated value of an uint in a bytes array.
 /// Only the least significant bytes from big-endian representation of the uint
 /// are stored in the result bytes array up to array's size.

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -969,10 +969,12 @@ constexpr uint512 operator"" _u512(const char* s) noexcept
 
 namespace le  // Conversions to/from LE bytes.
 {
-template <unsigned N>
-inline intx::uint<N> uint(const uint8_t (&bytes)[N / 8]) noexcept
+template <typename IntT, unsigned M>
+inline IntT load(const uint8_t (&bytes)[M]) noexcept
 {
-    auto x = intx::uint<N>{};
+    static_assert(M == IntT::num_bits / 8,
+        "the size of source bytes must match the size of the destination uint");
+    auto x = IntT{};
     std::memcpy(&x, bytes, sizeof(x));
     return x;
 }

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1008,6 +1008,19 @@ inline void store(uint8_t (&dst)[N / 8], const intx::uint<N>& x) noexcept
     std::memcpy(dst, &d, sizeof(d));
 }
 
+/// Stores the truncated value of an uint in a bytes array.
+/// Only the least significant bytes from big-endian representation of the uint
+/// are stored in the result bytes array up to array's size.
+template <unsigned M, unsigned N>
+inline void trunc(uint8_t (&dst)[M], const intx::uint<N>& x) noexcept
+{
+    static_assert(M < N / 8, "destination must be smaller than the source value");
+    const auto d = bswap(x);
+    const auto b = as_bytes(d);
+    std::memcpy(dst, &b[sizeof(d) - M], M);
+}
+
+
 }  // namespace be
 
 }  // namespace intx

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1000,6 +1000,12 @@ inline intx::uint<N> uint(const uint8_t (&bytes)[M]) noexcept
     return bswap(x);
 }
 
+template <unsigned N, typename T>
+inline intx::uint<N> uint(const T& t) noexcept
+{
+    return uint<N>(t.bytes);
+}
+
 /// Stores an uint value in a bytes array in big-endian order.
 template <unsigned N>
 inline void store(uint8_t (&dst)[N / 8], const intx::uint<N>& x) noexcept

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1006,6 +1006,16 @@ inline intx::uint<N> uint(const T& t) noexcept
     return uint<N>(t.bytes);
 }
 
+/// Loads an uint value from a buffer. The user must make sure
+/// that the provided buffer is big enough. Therefore marked "unsafe".
+template <unsigned N>
+inline intx::uint<N> uint_unsafe(const uint8_t* bytes) noexcept
+{
+    auto x = intx::uint<N>{};
+    std::memcpy(&x, bytes, sizeof(x));
+    return bswap(x);
+}
+
 /// Stores an uint value in a bytes array in big-endian order.
 template <unsigned N>
 inline void store(uint8_t (&dst)[N / 8], const intx::uint<N>& x) noexcept
@@ -1044,6 +1054,16 @@ inline T trunc(const intx::uint<N>& x) noexcept
     trunc(r.bytes, x);
     return r;
 }
+
+/// Stores an uint value at the provided pointer in big-endian order. The user must make sure
+/// that the provided buffer is big enough to fit the value. Therefore marked "unsafe".
+template <unsigned N>
+inline void store_unsafe(uint8_t* dst, const intx::uint<N>& x) noexcept
+{
+    const auto d = bswap(x);
+    std::memcpy(dst, &d, sizeof(d));
+}
+
 
 
 }  // namespace be

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1030,6 +1030,15 @@ inline void trunc(uint8_t (&dst)[M], const intx::uint<N>& x) noexcept
     std::memcpy(dst, &b[sizeof(d) - M], M);
 }
 
+/// Stores the truncated value of an uint in the .bytes field of an object of type T.
+template <typename T, unsigned N>
+inline T trunc(const intx::uint<N>& x) noexcept
+{
+    T r{};
+    trunc(r.bytes, x);
+    return r;
+}
+
 
 }  // namespace be
 

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -448,6 +448,11 @@ TYPED_TEST(uint_test, endianness)
     EXPECT_EQ(data[0], 0);
     EXPECT_EQ(data[s - 1], 1);
     EXPECT_EQ(be::uint<s * 8>(data), x);
+
+    be::store_unsafe(data, x);
+    EXPECT_EQ(data[0], 0);
+    EXPECT_EQ(data[s - 1], 1);
+    EXPECT_EQ(be::uint_unsafe<s * 8>(data), x);
 }
 
 TYPED_TEST(uint_test, be_zext)

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -447,7 +447,7 @@ TYPED_TEST(uint_test, endianness)
     be::store(data, x);
     EXPECT_EQ(data[0], 0);
     EXPECT_EQ(data[s - 1], 1);
-    EXPECT_EQ(be::uint<s * 8>(data), x);
+    EXPECT_EQ(be::load<s * 8>(data), x);
 
     be::store_unsafe(data, x);
     EXPECT_EQ(data[0], 0);
@@ -458,7 +458,7 @@ TYPED_TEST(uint_test, endianness)
 TYPED_TEST(uint_test, be_zext)
 {
     uint8_t data[] = {0x01, 0x02, 0x03};
-    const auto x = be::uint<TypeParam::num_bits>(data);
+    const auto x = be::load<TypeParam::num_bits>(data);
     EXPECT_EQ(x, 0x010203);
 }
 
@@ -468,7 +468,7 @@ TYPED_TEST(uint_test, be_load)
     uint8_t data[size]{};
     data[0] = 0x80;
     data[size - 1] = 1;
-    const auto x = be::uint<TypeParam::num_bits>(data);
+    const auto x = be::load<TypeParam::num_bits>(data);
     EXPECT_EQ(x, (TypeParam{1} << (TypeParam::num_bits - 1)) | 1);
 }
 
@@ -515,17 +515,17 @@ TYPED_TEST(uint_test, typed_trunc)
     EXPECT_EQ(s.bytes[0], 0);
 }
 
-TYPED_TEST(uint_test, typed_zext)
+TYPED_TEST(uint_test, typed_load_zext)
 {
     const auto s = storage<1>({0xed});
-    const auto x = be::uint<TypeParam::num_bits>(s);
+    const auto x = be::load<TypeParam::num_bits>(s);
     EXPECT_EQ(x, 0xed);
 }
 
 TYPED_TEST(uint_test, typed_load)
 {
     const auto s = storage<sizeof(TypeParam)>({0x88});
-    const auto x = be::uint<TypeParam::num_bits>(s);
+    const auto x = be::load<TypeParam::num_bits>(s);
     EXPECT_EQ(x, TypeParam{0x88} << (TypeParam::num_bits - 8));
 }
 

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -461,6 +461,16 @@ TYPED_TEST(uint_test, be_store)
     EXPECT_EQ(data[0], 0);
 }
 
+TYPED_TEST(uint_test, be_trunc)
+{
+    constexpr auto x = TypeParam{0xee48656c6c6f20536f6c617269732121_u128};
+    uint8_t out[15];
+    be::trunc(out, x);
+    const auto str = std::string{reinterpret_cast<char*>(out), sizeof(out)};
+    EXPECT_EQ(str, "Hello Solaris!!");
+}
+
+
 TYPED_TEST(uint_test, convert_to_bool)
 {
     EXPECT_TRUE((TypeParam{1, 0}));

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -447,18 +447,18 @@ TYPED_TEST(uint_test, endianness)
     be::store(data, x);
     EXPECT_EQ(data[0], 0);
     EXPECT_EQ(data[s - 1], 1);
-    EXPECT_EQ(be::load<s * 8>(data), x);
+    EXPECT_EQ(be::load<TypeParam>(data), x);
 
     be::store_unsafe(data, x);
     EXPECT_EQ(data[0], 0);
     EXPECT_EQ(data[s - 1], 1);
-    EXPECT_EQ(be::uint_unsafe<s * 8>(data), x);
+    EXPECT_EQ(be::unsafe_load<TypeParam>(data), x);
 }
 
 TYPED_TEST(uint_test, be_zext)
 {
     uint8_t data[] = {0x01, 0x02, 0x03};
-    const auto x = be::load<TypeParam::num_bits>(data);
+    const auto x = be::load<TypeParam>(data);
     EXPECT_EQ(x, 0x010203);
 }
 
@@ -468,7 +468,7 @@ TYPED_TEST(uint_test, be_load)
     uint8_t data[size]{};
     data[0] = 0x80;
     data[size - 1] = 1;
-    const auto x = be::load<TypeParam::num_bits>(data);
+    const auto x = be::load<TypeParam>(data);
     EXPECT_EQ(x, (TypeParam{1} << (TypeParam::num_bits - 1)) | 1);
 }
 
@@ -518,14 +518,14 @@ TYPED_TEST(uint_test, typed_trunc)
 TYPED_TEST(uint_test, typed_load_zext)
 {
     const auto s = storage<1>({0xed});
-    const auto x = be::load<TypeParam::num_bits>(s);
+    const auto x = be::load<TypeParam>(s);
     EXPECT_EQ(x, 0xed);
 }
 
 TYPED_TEST(uint_test, typed_load)
 {
     const auto s = storage<sizeof(TypeParam)>({0x88});
-    const auto x = be::load<TypeParam::num_bits>(s);
+    const auto x = be::load<TypeParam>(s);
     EXPECT_EQ(x, TypeParam{0x88} << (TypeParam::num_bits - 8));
 }
 

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -462,7 +462,7 @@ TYPED_TEST(uint_test, be_load)
     constexpr auto size = sizeof(TypeParam);
     uint8_t data[size]{};
     data[0] = 0x80;
-    data[size-1] = 1;
+    data[size - 1] = 1;
     const auto x = be::uint<TypeParam::num_bits>(data);
     EXPECT_EQ(x, (TypeParam{1} << (TypeParam::num_bits - 1)) | 1);
 }
@@ -485,6 +485,19 @@ TYPED_TEST(uint_test, be_trunc)
     be::trunc(out, x);
     const auto str = std::string{reinterpret_cast<char*>(out), sizeof(out)};
     EXPECT_EQ(str, "Hello Solaris!!");
+}
+
+template <unsigned M>
+struct storage
+{
+    uint8_t bytes[M];
+};
+
+TYPED_TEST(uint_test, typed_store)
+{
+    const auto x = TypeParam{2};
+    const auto s = be::store<storage<sizeof(x)>>(x);
+    EXPECT_EQ(s.bytes[sizeof(x) - 1], 2);
 }
 
 

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -450,6 +450,17 @@ TYPED_TEST(uint_test, endianness)
     EXPECT_EQ(be::uint<s * 8>(data), x);
 }
 
+TYPED_TEST(uint_test, be_store)
+{
+    const auto x = TypeParam{0x0201};
+    uint8_t data[sizeof(x)];
+    be::store(data, x);
+    EXPECT_EQ(data[sizeof(x) - 1], 1);
+    EXPECT_EQ(data[sizeof(x) - 2], 2);
+    EXPECT_EQ(data[sizeof(x) - 3], 0);
+    EXPECT_EQ(data[0], 0);
+}
+
 TYPED_TEST(uint_test, convert_to_bool)
 {
     EXPECT_TRUE((TypeParam{1, 0}));

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -510,6 +510,20 @@ TYPED_TEST(uint_test, typed_trunc)
     EXPECT_EQ(s.bytes[0], 0);
 }
 
+TYPED_TEST(uint_test, typed_zext)
+{
+    const auto s = storage<1>({0xed});
+    const auto x = be::uint<TypeParam::num_bits>(s);
+    EXPECT_EQ(x, 0xed);
+}
+
+TYPED_TEST(uint_test, typed_load)
+{
+    const auto s = storage<sizeof(TypeParam)>({0x88});
+    const auto x = be::uint<TypeParam::num_bits>(s);
+    EXPECT_EQ(x, TypeParam{0x88} << (TypeParam::num_bits - 8));
+}
+
 
 TYPED_TEST(uint_test, convert_to_bool)
 {

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -442,7 +442,7 @@ TYPED_TEST(uint_test, endianness)
     le::store(data, x);
     EXPECT_EQ(data[0], 1);
     EXPECT_EQ(data[s - 1], 0);
-    EXPECT_EQ(le::uint<s * 8>(data), x);
+    EXPECT_EQ(le::load<TypeParam>(data), x);
 
     be::store(data, x);
     EXPECT_EQ(data[0], 0);

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -500,6 +500,16 @@ TYPED_TEST(uint_test, typed_store)
     EXPECT_EQ(s.bytes[sizeof(x) - 1], 2);
 }
 
+TYPED_TEST(uint_test, typed_trunc)
+{
+    const auto x = TypeParam{0xaabb};
+    const auto s = be::trunc<storage<9>>(x);
+    EXPECT_EQ(s.bytes[8], 0xbb);
+    EXPECT_EQ(s.bytes[7], 0xaa);
+    EXPECT_EQ(s.bytes[6], 0);
+    EXPECT_EQ(s.bytes[0], 0);
+}
+
 
 TYPED_TEST(uint_test, convert_to_bool)
 {

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -450,6 +450,23 @@ TYPED_TEST(uint_test, endianness)
     EXPECT_EQ(be::uint<s * 8>(data), x);
 }
 
+TYPED_TEST(uint_test, be_zext)
+{
+    uint8_t data[] = {0x01, 0x02, 0x03};
+    const auto x = be::uint<TypeParam::num_bits>(data);
+    EXPECT_EQ(x, 0x010203);
+}
+
+TYPED_TEST(uint_test, be_load)
+{
+    constexpr auto size = sizeof(TypeParam);
+    uint8_t data[size]{};
+    data[0] = 0x80;
+    data[size-1] = 1;
+    const auto x = be::uint<TypeParam::num_bits>(data);
+    EXPECT_EQ(x, (TypeParam{1} << (TypeParam::num_bits - 1)) | 1);
+}
+
 TYPED_TEST(uint_test, be_store)
 {
     const auto x = TypeParam{0x0201};

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -449,10 +449,10 @@ TYPED_TEST(uint_test, endianness)
     EXPECT_EQ(data[s - 1], 1);
     EXPECT_EQ(be::load<TypeParam>(data), x);
 
-    be::store_unsafe(data, x);
+    be::unsafe::store(data, x);
     EXPECT_EQ(data[0], 0);
     EXPECT_EQ(data[s - 1], 1);
-    EXPECT_EQ(be::unsafe_load<TypeParam>(data), x);
+    EXPECT_EQ(be::unsafe::load<TypeParam>(data), x);
 }
 
 TYPED_TEST(uint_test, be_zext)

--- a/test/unittests/test_intx_api.cpp
+++ b/test/unittests/test_intx_api.cpp
@@ -8,9 +8,6 @@
 
 using namespace intx;
 
-static_assert(&le::uint<256> == le::uint256, "wrong alias: le::uint256");
-static_assert(&le::uint<512> == le::uint512, "wrong alias: le::uint512");
-
 static_assert(uint128{2} + uint128{2} == 4, "");
 static_assert(uint256{2} + uint256{2} == 4, "");
 static_assert(uint512{2} + uint512{2} == 4, "");

--- a/test/unittests/test_intx_api.cpp
+++ b/test/unittests/test_intx_api.cpp
@@ -8,8 +8,6 @@
 
 using namespace intx;
 
-static_assert(&be::uint<256> == be::uint256, "wrong alias: be::uint256");
-static_assert(&be::uint<512> == be::uint512, "wrong alias: be::uint512");
 static_assert(&le::uint<256> == le::uint256, "wrong alias: le::uint256");
 static_assert(&le::uint<512> == le::uint512, "wrong alias: le::uint512");
 


### PR DESCRIPTION
Closes #105.

This reworks and extends mostly the `intx::be` API for converting to/from bytes in big-endian order.

The usage is shown in https://github.com/ethereum/evmone/pull/131/files.

After prototyping the usage of new API, I propose further changes:

- Rename `uint<N>` to `load<uint<N>>`. In the end it is more consistent so see `be::load<uint256>(...)` instead of `be::uint<256>` and would allow to support other types like `be::load<int256>`.
- Rename `uint_unsafe()` to `unsafe_load()` or `unsafe::load()`. The later would allow hiding the "unsafe" mark with `using namespace intx::be::unsafe`.
- Rename `store_unsafe()` to `unsafe_store()` or `unsafe::store()`.