### PR TITLE
Optimize add and sub

### DIFF
--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -80,12 +80,20 @@ struct uint_with_carry
 /// Linear arithmetic operators.
 /// @{
 
+constexpr uint_with_carry<128> add_with_carry(uint128 a, uint128 b) noexcept
+{
+    const auto lo = a.lo + b.lo;
+    const auto lo_carry = lo < a.lo;
+    const auto t = a.hi + b.hi;
+    const auto carry1 = t < a.hi;
+    const auto hi = t + lo_carry;
+    const auto carry2 = hi < t;
+    return {{hi, lo}, carry1 || carry2};
+}
+
 constexpr uint128 operator+(uint128 x, uint128 y) noexcept
 {
-    const auto lo = x.lo + y.lo;
-    const auto carry = x.lo > lo;
-    const auto hi = x.hi + y.hi + carry;
-    return {hi, lo};
+    return add_with_carry(x, y).value;
 }
 
 constexpr uint128 operator+(uint128 x) noexcept
@@ -693,14 +701,6 @@ inline uint128& operator%=(uint128& x, uint128 y) noexcept
 }
 
 /// @}
-
-constexpr uint_with_carry<128> add_with_carry(uint128 a, uint128 b) noexcept
-{
-    // FIXME: Rename add_with_carry() to add_overflow().
-    const auto s = a + b;
-    const auto k = s < a;
-    return {s, k};
-}
 
 }  // namespace intx
 

--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -101,12 +101,20 @@ constexpr uint128 operator+(uint128 x) noexcept
     return x;
 }
 
+constexpr uint_with_carry<128> sub_with_borrow(uint128 a, uint128 b) noexcept
+{
+    const auto lo = a.lo - b.lo;
+    const auto lo_borrow = lo > a.lo;
+    const auto t = a.hi - b.hi;
+    const auto borrow1 = t > a.hi;
+    const auto hi = t - lo_borrow;
+    const auto borrow2 = hi > t;
+    return {{hi, lo}, borrow1 || borrow2};
+}
+
 constexpr uint128 operator-(uint128 x, uint128 y) noexcept
 {
-    const auto lo = x.lo - y.lo;
-    const auto borrow = x.lo < lo;
-    const auto hi = x.hi - y.hi - borrow;
-    return {hi, lo};
+    return sub_with_borrow(x, y).value;
 }
 
 constexpr uint128 operator-(uint128 x) noexcept

--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -69,6 +69,14 @@ struct uint<128>
 using uint128 = uint<128>;
 
 
+template <unsigned N>
+struct uint_with_carry
+{
+    uint<N> value;
+    bool carry;
+};
+
+
 /// Linear arithmetic operators.
 /// @{
 
@@ -685,6 +693,14 @@ inline uint128& operator%=(uint128& x, uint128 y) noexcept
 }
 
 /// @}
+
+constexpr uint_with_carry<128> add_with_carry(uint128 a, uint128 b) noexcept
+{
+    // FIXME: Rename add_with_carry() to add_overflow().
+    const auto s = a + b;
+    const auto k = s < a;
+    return {s, k};
+}
 
 }  // namespace intx
 

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -480,6 +480,16 @@ constexpr uint_with_carry<N> add_with_carry(const uint<N>& a, const uint<N>& b) 
     return {{hi.value, lo.value}, tt.carry || hi.carry};
 }
 
+
+template <unsigned N>
+constexpr uint_with_carry<N> sub_with_borrow(const uint<N>& a, const uint<N>& b) noexcept
+{
+    const auto lo = sub_with_borrow(a.lo, b.lo);
+    const auto tt = sub_with_borrow(a.hi, b.hi);
+    const auto hi = sub_with_borrow(tt.value, typename uint<N>::half_type{lo.carry});
+    return {{hi.value, lo.value}, tt.carry || hi.carry};
+}
+
 template <unsigned N>
 inline uint<N> add_loop(const uint<N>& a, const uint<N>& b) noexcept
 {
@@ -512,13 +522,14 @@ constexpr uint<N> operator+(const uint<N>& x, const uint<N>& y) noexcept
 template <unsigned N>
 constexpr uint<N> operator-(const uint<N>& x) noexcept
 {
+    // FIXME: Optimize as in uint128.
     return ~x + uint<N>{1};
 }
 
 template <unsigned N>
 constexpr uint<N> operator-(const uint<N>& x, const uint<N>& y) noexcept
 {
-    return x + -y;
+    return sub_with_borrow(x, y).value;
 }
 
 template <unsigned N, typename T,

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -472,21 +472,6 @@ inline uint<N> shl_loop(const uint<N>& x, unsigned shift)
 
 
 template <unsigned N>
-struct uint_with_carry
-{
-    uint<N> value;
-    bool carry;
-};
-
-constexpr uint_with_carry<128> add_with_carry(uint128 a, uint128 b) noexcept
-{
-    // FIXME: Rename add_with_carry() to add_overflow().
-    const auto s = a + b;
-    const auto k = s < a;
-    return {s, k};
-}
-
-template <unsigned N>
 constexpr uint_with_carry<N> add_with_carry(const uint<N>& a, const uint<N>& b) noexcept
 {
     const auto lo = add_with_carry(a.lo, b.lo);

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -522,7 +522,6 @@ constexpr uint<N> operator+(const uint<N>& x, const uint<N>& y) noexcept
 template <unsigned N>
 constexpr uint<N> operator-(const uint<N>& x) noexcept
 {
-    // FIXME: Optimize as in uint128.
     return ~x + uint<N>{1};
 }
 

--- a/test/benchmarks/benchmarks.cpp
+++ b/test/benchmarks/benchmarks.cpp
@@ -286,10 +286,10 @@ inline auto public_mul(const uint512& x, const uint512& y) noexcept
     return x * y;
 }
 
-BENCHMARK_TEMPLATE(binary_op512, inline_add);
 BENCHMARK_TEMPLATE(binary_op512, add);
-BENCHMARK_TEMPLATE(binary_op512, inline_sub);
+BENCHMARK_TEMPLATE(binary_op512, inline_add);
 BENCHMARK_TEMPLATE(binary_op512, sub);
+BENCHMARK_TEMPLATE(binary_op512, inline_sub);
 BENCHMARK_TEMPLATE(binary_op512, mul);
 BENCHMARK_TEMPLATE(binary_op512, public_mul);
 BENCHMARK_TEMPLATE(binary_op512, gmp::mul);

--- a/test/experimental/add.cpp
+++ b/test/experimental/add.cpp
@@ -69,21 +69,37 @@ uint192 add_waterfall(
 
 uint256 add_recursive(const uint256& a, const uint256& b) noexcept
 {
-    const auto ll = a.lo.lo + b.lo.lo;
-    const auto l_carry = ll < a.lo.lo;
-    const auto lh = a.lo.hi + b.lo.hi + l_carry;
+    uint128 lo;
+    bool lo_carry;
+    {
+        const auto l = a.lo.lo + b.lo.lo;
+        const auto l_carry = l < a.lo.lo;
+        const auto t = a.lo.hi + b.lo.hi;
+        const auto carry1 = t < a.lo.hi;
+        const auto h = t + l_carry;
+        const auto carry2 = h < t;
+        lo = uint128{h, l};
+        lo_carry = carry1 || carry2;
+    }
 
-    const bool lo_carry = (lh < a.lo.hi) | ((lh == a.lo.hi) & l_carry);
+    uint128 tt;
+    {
+        const auto l = a.hi.lo + b.hi.lo;
+        const auto l_carry = l < a.hi.lo;
+        const auto t = a.hi.hi + b.hi.hi;
+        const auto h = t + l_carry;
+        tt = uint128{h, l};
+    }
 
-    const auto tl = a.hi.lo + b.hi.lo;
-    const auto t_carry = tl < a.hi.lo;
-    const auto th = a.hi.hi + b.hi.hi + t_carry;
+    uint128 hi;
+    {
+        const auto l = tt.lo + lo_carry;
+        const auto l_carry = l < tt.lo;
+        const auto h = tt.hi + l_carry;
+        hi = uint128{h, l};
+    }
 
-    const auto hl = tl + lo_carry;
-    const auto hl_carry = hl < tl;
-    const auto hh = th + hl_carry;
-
-    return {{hh, hl}, {lh, ll}};
+    return {hi, lo};
 }
 
 uint256 add_waterflow(const uint256& a, const uint256& b) noexcept


### PR DESCRIPTION
This rewrites the `add_with_carry()` for `uint128` to a bit more efficient form (easier to consume by compilers).
Also subtraction is implemented in the analogous way to additions, instead of reusing addition.

GCC9:
```
Comparing test/intx-bench-master to test/intx-bench
Benchmark                           Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------
binary_op256<add>                +0.0007         +0.0007          7186          7191          7186          7191
binary_op256<inline_add>         -0.1695         -0.1695          2317          1924          2317          1924
binary_op256<sub>                -0.1624         -0.1625          8707          7293          8707          7292
binary_op256<inline_sub>         -0.4819         -0.4818          4041          2094          4041          2094
binary_op512<inline_add>         -0.2374         -0.2376          6874          5242          6874          5241
binary_op512<add>                -0.1954         -0.1954          9001          7242          9001          7242
binary_op512<inline_sub>         -0.4907         -0.4907         10430          5312         10430          5312
binary_op512<sub>                -0.1773         -0.1774         12260         10086         12259         10084
```

Clang9:
```
Comparing test/intx-bench-master to test/intx-bench
Benchmark                           Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------
binary_op256<add>                -0.0524         -0.0503          7908          7493          7890          7493
binary_op256<inline_add>         -0.0452         -0.0431          1973          1884          1969          1884
binary_op256<sub>                -0.1284         -0.1258          8552          7454          8527          7454
binary_op256<inline_sub>         -0.3132         -0.3114          2783          1911          2776          1911
binary_op512<inline_add>         -0.5603         -0.5585          9824          4319          9783          4319
binary_op512<add>                -0.0133         -0.0108         11674         11519         11644         11519
binary_op512<inline_sub>         -0.3870         -0.3880          7972          4886          7965          4874
binary_op512<sub>                -0.0672         -0.0692         11794         11001         11794         10978
```