### PR TITLE
Small optimization for reciprocal 3by2

### DIFF
--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -555,12 +555,13 @@ inline uint64_t reciprocal_3by2(uint128 d) noexcept
     if (p < d.lo)
     {
         --v;
-        if (p >= d.hi)
+        const auto p0 = p;
+        p -= d.hi;
+        if (p <= p0)  // Subtraction without borrow.
         {
             --v;
             p -= d.hi;
         }
-        p -= d.hi;
     }
 
     const auto t = umul(v, d.lo);

--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -554,14 +554,13 @@ inline uint64_t reciprocal_3by2(uint128 d) noexcept
     p += d.lo;
     if (p < d.lo)
     {
-        --v;
-        const auto p0 = p;
-        p -= d.hi;
-        if (p <= p0)  // Subtraction without borrow.
+        if (p >= d.hi)
         {
-            --v;
             p -= d.hi;
+            --v;
         }
+        p -= d.hi;
+        --v;
     }
 
     const auto t = umul(v, d.lo);


### PR DESCRIPTION
Two small tweaks to `reciprocal_3by2()` implementation. They don't make any difference, but leaving the PR to document the attempt.