### PR TITLE
Optimize exponentiation of base 2

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -593,6 +593,9 @@ template <unsigned N>
 constexpr uint<N> exp(uint<N> base, uint<N> exponent) noexcept
 {
     auto result = uint<N>{1};
+    if (base == 2)
+        return result << exponent;
+
     while (exponent != 0)
     {
         if ((exponent & 1) != 0)


### PR DESCRIPTION
This replaces `2 ^ E` with `1 << E` as suggested in https://github.com/ethereum/evmone/pull/233.

Three versions have been tried
1. ```cpp
   result << exponent 
   ```
2. ```cpp
   if (exponent < N)
   {
       auto exp_bytes = as_bytes(exponent);
       uint8_t bit_to_set = exp_bytes[0];
       exp_bytes[0] = 0;
       exp_bytes[bit_to_set >> 3] = uint8_t(uint8_t(1) << (bit_to_set & 7));
       return exponent;
   }
3. ```cpp
   auto result = uint<N>{0};
   if (exponent < N)
   {
       auto bit_to_set = static_cast<uint64_t>(exponent);
       as_words(result)[bit_to_set / 64] = uint64_t{1} << (bit_to_set % 64);
   }
   return result;
   ```

Comparing master with v1:
```
Benchmark                                    Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------
exponentiation/64_mean                    -0.0575         -0.0575           737           695           737           695
exponentiation/128_mean                   -0.0423         -0.0423          1513          1449          1513          1449
exponentiation/192_mean                   -0.0325         -0.0325          2279          2205          2279          2205
exponentiation/256_mean                   -0.0316         -0.0316          3059          2963          3059          2963
exponentiation2/0_mean                    +0.0486         +0.0485             5             5             5             5
exponentiation2/64_mean                   -0.8878         -0.8878            48             5            48             5
exponentiation2/128_mean                  -0.8969         -0.8969            54             6            54             6
exponentiation2/256_mean                  -0.9117         -0.9117            59             5            59             5
exponentiation2/512_mean                  -0.9192         -0.9192            65             5            65             5
```

The group `exponentiation/N` is random base by random exponent with N bits exponentiation. Not sure why they have become faster.

Fortunately, the version 1 is also faster than v2 and v3, so this one is going to be merged.

Comparing v1 to v2:
```
Benchmark                                    Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------
exponentiation2/0_mean                    +1.6372         +1.6372             5            14             5            14
exponentiation2/64_mean                   +1.5614         +1.5614             5            14             5            14
exponentiation2/128_mean                  +1.5225         +1.5225             6            14             6            14
exponentiation2/256_mean                  +0.6367         +0.6367             5             9             5             9
exponentiation2/512_mean                  +0.6348         +0.6348             5             9             5             9
```

Comparing v1 to v3:
```
Benchmark                                    Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------
exponentiation2/0_mean                    +0.9607         +0.9607             5            10             5            10
exponentiation2/64_mean                   +0.9419         +0.9419             5            10             5            10
exponentiation2/128_mean                  +0.8064         +0.8064             6            10             6            10
exponentiation2/256_mean                  +0.0800         +0.0800             5             6             5             6
exponentiation2/512_mean                  +0.0828         +0.0828             5             6             5             6
```