### PR TITLE
Faster (compared to ==0) is_zero

### DIFF
--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -234,6 +234,11 @@ constexpr bool operator!=(uint128 x, uint128 y) noexcept
     return (x.lo != y.lo) | (x.hi != y.hi);
 }
 
+constexpr bool is_zero(uint128 x) noexcept
+{
+    return (x.lo | x.hi) == 0;
+}
+
 constexpr bool operator<(uint128 x, uint128 y) noexcept
 {
     // OPT: This should be implemented by checking the borrow of x - y,

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -149,6 +149,11 @@ constexpr bool operator!=(const T& x, const uint<N>& y) noexcept
     return uint<N>(x) != y;
 }
 
+template <unsigned N>
+constexpr bool is_zero(const uint<N>& x) noexcept
+{
+    return is_zero(x.lo) & is_zero(x.hi);
+}
 
 template <unsigned N>
 constexpr bool operator<(const uint<N>& a, const uint<N>& b) noexcept

--- a/test/benchmarks/benchmarks.cpp
+++ b/test/benchmarks/benchmarks.cpp
@@ -305,4 +305,34 @@ BENCHMARK_TEMPLATE(to_string, uint128);
 BENCHMARK_TEMPLATE(to_string, uint256);
 BENCHMARK_TEMPLATE(to_string, uint512);
 
+template <typename ResultT, typename ArgT, ResultT UnOp(const ArgT&)>
+static void unary_op(benchmark::State& state)
+{
+    const auto& xs = test::get_samples<ArgT>(sizeof(ArgT) == sizeof(uint256) ? x_256 : x_512);
+
+    while (state.KeepRunningBatch(xs.size()))
+    {
+        for (size_t i = 0; i < xs.size(); ++i)
+        {
+            const auto _ = UnOp(xs[i]);
+            benchmark::DoNotOptimize(_);
+        }
+    }
+}
+
+inline bool op_eq_0(const uint256& x) noexcept
+{
+    return x == 0;
+}
+
+inline bool op_eq_0(const uint512& x) noexcept
+{
+    return x == 0;
+}
+
+BENCHMARK_TEMPLATE(unary_op, bool, uint256, op_eq_0);
+BENCHMARK_TEMPLATE(unary_op, bool, uint256, is_zero);
+BENCHMARK_TEMPLATE(unary_op, bool, uint512, op_eq_0);
+BENCHMARK_TEMPLATE(unary_op, bool, uint512, is_zero);
+
 BENCHMARK_MAIN();

--- a/test/unittests/test_int128.cpp
+++ b/test/unittests/test_int128.cpp
@@ -192,6 +192,15 @@ static_assert(uint128(13) - 17 == uint128{0xffffffffffffffff, 0xfffffffffffffffc
 
 static_assert(-a == (~a + 1), "");
 static_assert(+a == a, "");
+
+static_assert(a != 0, "");
+static_assert(0 != s, "");
+static_assert(!is_zero(a), "");
+static_assert(!is_zero(s), "");
+static_assert(a - a == 0, "");
+static_assert(0 == s - a - a, "");
+static_assert(is_zero(a - a), "");
+static_assert(is_zero(s - a - a), "");
 }  // namespace static_test_arith
 #endif
 
@@ -366,13 +375,13 @@ TEST(int128, from_string)
 {
     constexpr auto ka = from_string<uint128>("18446744073709551617");
     static_assert(ka == uint128{1, 1}, "");
-    const auto *const sa = "18446744073709551617";
+    const auto* const sa = "18446744073709551617";
     const auto a = from_string<uint128>(sa);
     EXPECT_EQ(a, uint128(1, 1));
 
     constexpr auto kb = from_string<uint128>("0x300aabbccddeeff99");
     static_assert(kb == uint128{3, 0xaabbccddeeff99}, "");
-    const auto *const sb = "0x300aabbccddeeff99";
+    const auto* const sb = "0x300aabbccddeeff99";
     EXPECT_EQ(from_string<uint128>(sb), uint128(3, 0xaabbccddeeff99));
 }
 

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -297,6 +297,11 @@ TYPED_TEST(uint_test, comparison)
     EXPECT_GE(z10, z10);
     EXPECT_GE(z11, z10);
     EXPECT_GE(z11, z11);
+
+    EXPECT_TRUE(is_zero(z00));
+    EXPECT_FALSE(is_zero(z01));
+    EXPECT_FALSE(is_zero(z10));
+    EXPECT_FALSE(is_zero(z11));
 }
 
 TYPED_TEST(uint_test, bitwise)


### PR DESCRIPTION
Benchmark results on my MacBook:
```
unary_op<bool, uint256, op_eq_0>                             21 ns         21 ns   33263638
unary_op<bool, uint256, is_zero>                              8 ns          8 ns   87683038
unary_op<bool, uint512, op_eq_0>                             42 ns         42 ns   16355140
unary_op<bool, uint512, is_zero>                             14 ns         14 ns   49587714
```