### PR TITLE
int128: Cleanup conversion to __int128

### DIFF
--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -84,7 +84,8 @@ struct uint<128>
 
     constexpr explicit operator unsigned __int128() const noexcept
     {
-        return (static_cast<unsigned __int128>(hi) << 64) | lo;
+        using builtin_uint128 = unsigned __int128;
+        return (builtin_uint128{hi} << 64) | lo;
     }
     #pragma GCC diagnostic pop
 #endif
@@ -370,7 +371,8 @@ inline uint128 umul(uint64_t x, uint64_t y) noexcept
 #if defined(__SIZEOF_INT128__)
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wpedantic"
-    const auto p = static_cast<unsigned __int128>(x) * y;
+    using builtin_uint128 = unsigned __int128;
+    const auto p = builtin_uint128{x} * y;
     return {uint64_t(p >> 64), uint64_t(p)};
     #pragma GCC diagnostic pop
 #elif defined(_MSC_VER)


### PR DESCRIPTION
Use guaranteed lossless conversion with {}.