### PR TITLE
Change uint128 struct to array uint64_t[2]

### DIFF
--- a/test/benchmarks/bench_div.cpp
+++ b/test/benchmarks/bench_div.cpp
@@ -56,7 +56,7 @@ inline uint64_t reciprocal_naive(uint64_t d) noexcept
     v = (u / d).lo;
 #else
     uint64_t _;
-    asm("divq %4" : "=d"(_), "=a"(v) : "d"(u.hi), "a"(u.lo), "g"(d));
+    asm("divq %4" : "=d"(_), "=a"(v) : "d"(u.words[1]), "a"(u.words[0]), "g"(d));
 #endif
 
     return v;

--- a/test/benchmarks/bench_int128.cpp
+++ b/test/benchmarks/bench_int128.cpp
@@ -68,8 +68,8 @@ static void umul128(benchmark::State& state)
         for (size_t i = 0; i < inputs.size() - 1; ++i)
         {
             auto p = MulFn(inputs[i], inputs[i + 1]);
-            alo ^= p.lo;
-            ahi ^= p.hi;
+            alo ^= p.words[0];
+            ahi ^= p.words[1];
         }
         benchmark::DoNotOptimize(alo);
         benchmark::DoNotOptimize(ahi);

--- a/test/experimental/add.cpp
+++ b/test/experimental/add.cpp
@@ -74,10 +74,10 @@ uint256 add_recursive(const uint256& a, const uint256& b) noexcept
     uint128 lo;
     bool lo_carry;
     {
-        const auto l = a.lo.lo + b.lo.lo;
-        const auto l_carry = l < a.lo.lo;
-        const auto t = a.lo.hi + b.lo.hi;
-        const auto carry1 = t < a.lo.hi;
+        const auto l = a.lo.words[0] + b.lo.words[0];
+        const auto l_carry = l < a.lo.words[0];
+        const auto t = a.lo.words[1] + b.lo.words[1];
+        const auto carry1 = t < a.lo.words[1];
         const auto h = t + l_carry;
         const auto carry2 = h < t;
         lo = uint128{h, l};
@@ -86,18 +86,18 @@ uint256 add_recursive(const uint256& a, const uint256& b) noexcept
 
     uint128 tt;
     {
-        const auto l = a.hi.lo + b.hi.lo;
-        const auto l_carry = l < a.hi.lo;
-        const auto t = a.hi.hi + b.hi.hi;
+        const auto l = a.hi.words[0] + b.hi.words[0];
+        const auto l_carry = l < a.hi.words[0];
+        const auto t = a.hi.words[1] + b.hi.words[1];
         const auto h = t + l_carry;
         tt = uint128{h, l};
     }
 
     uint128 hi;
     {
-        const auto l = tt.lo + lo_carry;
-        const auto l_carry = l < tt.lo;
-        const auto h = tt.hi + l_carry;
+        const auto l = tt.words[0] + lo_carry;
+        const auto l_carry = l < tt.words[0];
+        const auto h = tt.words[1] + l_carry;
         hi = uint128{h, l};
     }
 
@@ -106,22 +106,22 @@ uint256 add_recursive(const uint256& a, const uint256& b) noexcept
 
 uint256 add_waterflow(const uint256& a, const uint256& b) noexcept
 {
-    const auto ll = a.lo.lo + b.lo.lo;
-    auto carry = ll < a.lo.lo;
+    const auto ll = a.lo.words[0] + b.lo.words[0];
+    auto carry = ll < a.lo.words[0];
 
-    auto lh = a.lo.hi + b.lo.hi;
-    auto k1 = lh < a.lo.hi;
+    auto lh = a.lo.words[1] + b.lo.words[1];
+    auto k1 = lh < a.lo.words[1];
     lh += carry;
     auto k2 = lh < uint64_t{carry};
     carry = k1 | k2;
 
-    auto hl = a.hi.lo + b.hi.lo;
-    k1 = hl < a.hi.lo;
+    auto hl = a.hi.words[0] + b.hi.words[0];
+    k1 = hl < a.hi.words[0];
     hl += carry;
     k2 = hl < uint64_t{carry};
     carry = k1 | k2;
 
-    auto hh = a.hi.hi + b.hi.hi;
+    auto hh = a.hi.words[1] + b.hi.words[1];
     hh += carry;
 
     return {{hh, hl}, {lh, ll}};

--- a/test/unittests/test_div.cpp
+++ b/test/unittests/test_div.cpp
@@ -381,9 +381,9 @@ inline uint64_t reciprocal_naive(uint64_t d) noexcept
 
 #if __x86_64__
     uint64_t _;
-    asm("divq %4" : "=d"(_), "=a"(v) : "d"(u.hi), "a"(u.lo), "g"(d));
+    asm("divq %4" : "=d"(_), "=a"(v) : "d"(u.words[1]), "a"(u.words[0]), "g"(d));
 #else
-    v = (u / d).lo;
+    v = (u / d).words[0];
 #endif
 
     return v;

--- a/test/unittests/test_int128.cpp
+++ b/test/unittests/test_int128.cpp
@@ -202,6 +202,7 @@ TEST(int128, numeric_limits)
     static_assert(std::numeric_limits<uint128>::is_exact, "");
     static_assert(std::numeric_limits<uint128>::radix == 2, "");
 
+    static_assert(std::numeric_limits<uint128>::digits == 128, "");
     static_assert(std::numeric_limits<uint128>::digits10 == 38, "");
     static_assert(std::numeric_limits<uint128>::min() == 0, "");
     static_assert(std::numeric_limits<uint128>::max() == uint128{0} - 1, "");
@@ -421,7 +422,7 @@ TEST(int128, umul)
         const auto best = intx::umul(x, y);
 
         EXPECT_EQ(generic, best) << x << " x " << y;
-        EXPECT_EQ(generic.lo, x * y);
+        EXPECT_EQ(generic.words[0], x * y);
     }
 }
 

--- a/test/utils/random.cpp
+++ b/test/utils/random.cpp
@@ -36,7 +36,7 @@ bool init() noexcept
         samples_64_norm[i] |= 0x8000000000000000;
 
         gen_int(samples_128_norm[i], 2);
-        samples_128_norm[i].hi |= 0x8000000000000000;
+        samples_128_norm[i].words[1] |= 0x8000000000000000;
 
         gen_int(samples_256[x_64][i], 1);
         samples_512[x_64][i] = samples_256[x_64][i];


### PR DESCRIPTION
This is the first part of intx internal structure redesign: converting
intx being two parts: low and high to being an array of 64-bit words.

#185 