### PR TITLE
Introduce temporary uintw type for words array representation

### DIFF
--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -132,18 +132,12 @@ constexpr inline result_with_carry<uint64_t> add_with_carry(
     return {t, carry1 || carry2};
 }
 
-template <unsigned N>
-constexpr result_with_carry<uint<N>> add_with_carry(
-    const uint<N>& a, const uint<N>& b, bool carry = false) noexcept
-{
-    const auto lo = add_with_carry(a.lo, b.lo, carry);
-    const auto hi = add_with_carry(a.hi, b.hi, lo.carry);
-    return {{hi.value, lo.value}, hi.carry};
-}
-
 constexpr inline uint128 operator+(uint128 x, uint128 y) noexcept
 {
-    return add_with_carry(x, y).value;
+    // FIXME: Remove later.
+    const auto lo = add_with_carry(x.lo, y.lo);
+    const auto hi = add_with_carry(x.hi, y.hi, lo.carry);
+    return {hi.value, lo.value};
 }
 
 constexpr inline uint128 operator+(uint128 x) noexcept

--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -98,6 +98,10 @@ struct uint<128>
     {
         return static_cast<Int>(lo);
     }
+
+    inline constexpr uint64_t& word(size_t i) noexcept { return (i == 0) ? lo : hi; }
+
+    inline constexpr const uint64_t& word(size_t i) const noexcept { return (i == 0) ? lo : hi; }
 };
 
 using uint128 = uint<128>;

--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -155,20 +155,11 @@ constexpr inline result_with_carry<uint64_t> sub_with_carry(
     return {e, carry1 || carry2};
 }
 
-/// Performs subtraction of two unsigned numbers and returns the difference
-/// and the carry bit (aka borrow, overflow).
-template <unsigned N>
-constexpr inline result_with_carry<uint<N>> sub_with_carry(
-    const uint<N>& a, const uint<N>& b, bool carry = false) noexcept
-{
-    const auto lo = sub_with_carry(a.lo, b.lo, carry);
-    const auto hi = sub_with_carry(a.hi, b.hi, lo.carry);
-    return {{hi.value, lo.value}, hi.carry};
-}
-
 constexpr inline uint128 operator-(uint128 x, uint128 y) noexcept
 {
-    return sub_with_carry(x, y).value;
+    const auto lo = sub_with_carry(x.lo, y.lo);
+    const auto hi = sub_with_carry(x.hi, y.hi, lo.carry);
+    return {hi.value, lo.value};
 }
 
 constexpr inline uint128 operator-(uint128 x) noexcept

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -447,26 +447,20 @@ inline uint<N> shl_loop(const uint<N>& x, unsigned shift)
 }
 
 template <unsigned N>
-inline uint<N> add_loop(const uint<N>& a, const uint<N>& b) noexcept
+constexpr result_with_carry<uint<N>> add_with_carry(
+    const uint<N>& x, const uint<N>& y, bool carry = false) noexcept
 {
-    static constexpr auto num_words = sizeof(a) / sizeof(uint64_t);
+    const uintw<N> u{x};
+    const uintw<N> v{y};
 
-    auto x = as_words(a);
-    auto y = as_words(b);
-
-    uint<N> s;
-    auto z = as_words(s);
-
-    bool k = false;
-    for (size_t i = 0; i < num_words; ++i)
+    uintw<N> s;
+    for (size_t i = 0; i < u.num_words; ++i)
     {
-        z[i] = x[i] + y[i];
-        auto k1 = z[i] < x[i];
-        z[i] += k;
-        k = (z[i] < k) || k1;
+        const auto r = add_with_carry(u[i], v[i], carry);
+        s[i] = r.value;
+        carry = r.carry;
     }
-
-    return s;
+    return {s, carry};
 }
 
 template <unsigned N>

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -479,11 +479,19 @@ constexpr uint<N> operator-(const uint<N>& x) noexcept
 /// and the carry bit (aka borrow, overflow).
 template <unsigned N>
 constexpr inline result_with_carry<uint<N>> sub_with_carry(
-    const uint<N>& a, const uint<N>& b, bool carry = false) noexcept
+    const uint<N>& x, const uint<N>& y, bool carry = false) noexcept
 {
-    const auto lo = sub_with_carry(a.lo, b.lo, carry);
-    const auto hi = sub_with_carry(a.hi, b.hi, lo.carry);
-    return {{hi.value, lo.value}, hi.carry};
+    const uintw<N> u{x};
+    const uintw<N> v{y};
+
+    uintw<N> s;
+    for (size_t i = 0; i < u.num_words; ++i)
+    {
+        const auto r = sub_with_carry(u[i], v[i], carry);
+        s[i] = r.value;
+        carry = r.carry;
+    }
+    return {s, carry};
 }
 
 template <unsigned N>

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -70,6 +70,33 @@ struct uint
 using uint256 = uint<256>;
 using uint512 = uint<512>;
 
+template <unsigned N>
+struct uintw
+{
+    static constexpr std::size_t num_words = N / (sizeof(uint64_t) * 8);
+
+    uint64_t words[num_words]{};
+
+    uintw() = default;
+
+    inline constexpr explicit uintw(const uint<N>& o) noexcept
+    {
+        for (size_t i = 0; i < num_words; ++i)
+            words[i] = o.word(i);
+    }
+
+    inline constexpr operator uint<N>() noexcept
+    {
+        uint<N> r;
+        for (size_t i = 0; i < num_words; ++i)
+            r.word(i) = words[i];
+        return r;
+    }
+
+    inline constexpr uint64_t& operator[](std::size_t i) noexcept { return words[i]; }
+    inline constexpr const uint64_t& operator[](std::size_t i) const noexcept { return words[i]; }
+};
+
 constexpr uint8_t lo_half(uint16_t x)
 {
     return static_cast<uint8_t>(x);

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -475,6 +475,17 @@ constexpr uint<N> operator-(const uint<N>& x) noexcept
     return ~x + uint<N>{1};
 }
 
+/// Performs subtraction of two unsigned numbers and returns the difference
+/// and the carry bit (aka borrow, overflow).
+template <unsigned N>
+constexpr inline result_with_carry<uint<N>> sub_with_carry(
+    const uint<N>& a, const uint<N>& b, bool carry = false) noexcept
+{
+    const auto lo = sub_with_carry(a.lo, b.lo, carry);
+    const auto hi = sub_with_carry(a.hi, b.hi, lo.carry);
+    return {{hi.value, lo.value}, hi.carry};
+}
+
 template <unsigned N>
 constexpr uint<N> operator-(const uint<N>& x, const uint<N>& y) noexcept
 {

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -55,6 +55,16 @@ struct uint
     {
         return static_cast<Int>(lo);
     }
+
+    inline constexpr uint64_t& word(size_t i) noexcept
+    {
+        return (i >= num_words / 2) ? hi.word(i - num_words / 2) : lo.word(i);
+    }
+
+    inline constexpr const uint64_t& word(size_t i) const noexcept
+    {
+        return (i >= num_words / 2) ? hi.word(i - num_words / 2) : lo.word(i);
+    }
 };
 
 using uint256 = uint<256>;


### PR DESCRIPTION
This adds `uintw` temporary type. Then we can rewrite all functions to be using uintw/words instead of lo/hi. In the end the `uintw` should replace `uint`. 
Here there is an example rewrite for addition.