### PR TITLE
Always use mul_loop_opt() for multiplication (operator*)

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -582,11 +582,6 @@ inline uint<N> mul_loop_opt(const uint<N>& x, const uint<N>& y) noexcept
     return p;
 }
 
-inline uint256 operator*(const uint256& x, const uint256& y) noexcept
-{
-    return mul(x, y);
-}
-
 template <unsigned N>
 inline uint<N> operator*(const uint<N>& x, const uint<N>& y) noexcept
 {

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -535,19 +535,19 @@ constexpr uint<N> constexpr_mul(const uint<N>& a, const uint<N>& b) noexcept
 template <unsigned N>
 inline uint<2 * N> umul_loop(const uint<N>& x, const uint<N>& y) noexcept
 {
-    constexpr int num_words = sizeof(uint<N>) / sizeof(uint64_t);
+    constexpr auto num_words = sizeof(uint<N>) / sizeof(uint64_t);
 
     uint<2 * N> p;
     auto pw = as_words(p);
-    auto uw = as_words(x);
-    auto vw = as_words(y);
+    const auto xw = as_words(x);
+    const auto yw = as_words(y);
 
-    for (int j = 0; j < num_words; ++j)
+    for (size_t j = 0; j < num_words; ++j)
     {
         uint64_t k = 0;
-        for (int i = 0; i < num_words; ++i)
+        for (size_t i = 0; i < num_words; ++i)
         {
-            auto t = umul(uw[i], vw[j]) + pw[i + j] + k;
+            const auto t = umul(xw[i], yw[j]) + pw[i + j] + k;
             pw[i + j] = t.lo;
             k = t.hi;
         }
@@ -556,26 +556,28 @@ inline uint<2 * N> umul_loop(const uint<N>& x, const uint<N>& y) noexcept
     return p;
 }
 
+/// Multiplication implementation using word access
+/// and discarding the high part of the result product.
 template <unsigned N>
-inline uint<N> mul_loop_opt(const uint<N>& u, const uint<N>& v) noexcept
+inline uint<N> mul_loop_opt(const uint<N>& x, const uint<N>& y) noexcept
 {
-    constexpr int num_words = sizeof(uint<N>) / sizeof(uint64_t);
+    constexpr auto num_words = sizeof(uint<N>) / sizeof(uint64_t);
 
     uint<N> p;
     auto pw = as_words(p);
-    auto uw = as_words(u);
-    auto vw = as_words(v);
+    const auto xw = as_words(x);
+    const auto yw = as_words(y);
 
-    for (int j = 0; j < num_words; j++)
+    for (size_t j = 0; j < num_words; j++)
     {
         uint64_t k = 0;
-        for (int i = 0; i < (num_words - j - 1); i++)
+        for (size_t i = 0; i < (num_words - j - 1); i++)
         {
-            auto t = umul(uw[i], vw[j]) + pw[i + j] + k;
+            const auto t = umul(xw[i], yw[j]) + pw[i + j] + k;
             pw[i + j] = t.lo;
             k = t.hi;
         }
-        pw[num_words - 1] += uw[num_words - j - 1] * vw[j] + k;
+        pw[num_words - 1] += xw[num_words - j - 1] * yw[j] + k;
     }
     return p;
 }


### PR DESCRIPTION
This turned out to be the fastest procedure if benchmarked correctly. Only the "public_mul" for `uint256` should be affected.

Skylake, Clang11
```
binop<uint256, uint256, mul_>_mean                           -0.0003         -0.0003            13            12            13            12
binop<uint256, uint256, mul_loop_>_mean                      +0.0032         +0.0032            30            30            30            30
binop<uint256, uint256, mul_loop_opt_>_mean                  -0.0006         -0.0006            11            11            11            11
binop<uint256, uint256, public_mul>_mean                     -0.0474         -0.0474            12            12            12            12
binop<uint256, uint256, gmp::mul>_mean                       +0.0361         +0.0361            29            30            29            30
binop<uint512, uint256, umul_>_mean                          +0.0007         +0.0006            29            29            29            29
binop<uint512, uint256, umul_loop_>_mean                     +0.0163         +0.0089            25            26            25            26
binop<uint512, uint256, gmp::mul_full>_mean                  +0.0560         +0.0477            29            31            29            30
binop<uint512, uint512, mul_>_mean                           +0.0390         +0.0305            53            55            53            54
binop<uint512, uint512, mul_loop_>_mean                      +0.0216         +0.0131           109           111           109           110
binop<uint512, uint512, mul_loop_opt_>_mean                  +0.0309         +0.0220            48            49            48            49
binop<uint512, uint512, public_mul>_mean                     +0.0265         +0.0182            48            49            48            49
binop<uint512, uint512, gmp::mul>_mean                       +0.0292         +0.0206            88            91            88            90
```

Haswell, Clang11
```
binop<uint256, uint256, mul_>_mean                           +0.0005         +0.0005             6             6             6             6
binop<uint256, uint256, mul_loop_>_mean                      +0.0007         +0.0007            13            13            13            13
binop<uint256, uint256, mul_loop_opt_>_mean                  -0.0127         -0.0127             5             5             5             5
binop<uint256, uint256, public_mul>_mean                     -0.0353         -0.0353             6             5             6             5
binop<uint256, uint256, gmp::mul>_mean                       -0.0003         -0.0003            14            14            14            14
binop<uint512, uint256, umul_>_mean                          -0.0011         -0.0011            13            13            13            13
binop<uint512, uint256, umul_loop_>_mean                     -0.0001         -0.0001            12            12            12            12
binop<uint512, uint256, gmp::mul_full>_mean                  -0.0011         -0.0011            14            14            14            14
binop<uint512, uint512, mul_>_mean                           +0.0322         +0.0322            24            25            24            25
binop<uint512, uint512, mul_loop_>_mean                      +0.0021         +0.0021            50            50            50            50
binop<uint512, uint512, mul_loop_opt_>_mean                  +0.0083         +0.0083            22            22            22            22
binop<uint512, uint512, public_mul>_mean                     +0.0078         +0.0078            22            22            22            22
binop<uint512, uint512, gmp::mul>_mean                       +0.0010         +0.0010            46            46            46            46
```

Skylake, GCC10 (here `int` -> `size_t` also helps).
```
binop<uint256, uint256, mul_>_mean                           +0.0000         +0.0001            23            23            23            23
binop<uint256, uint256, mul_loop_>_mean                      -0.0003         -0.0003            33            33            33            33
binop<uint256, uint256, mul_loop_opt_>_mean                  +0.0278         +0.0279            20            21            20            21
binop<uint256, uint256, public_mul>_mean                     -0.1187         -0.1187            23            21            23            21
binop<uint256, uint256, gmp::mul>_mean                       +0.0150         +0.0142            31            31            30            31
binop<uint512, uint256, umul_>_mean                          -0.0012         -0.0009            47            47            47            47
binop<uint512, uint256, umul_loop_>_mean                     -0.0013         -0.0012            44            44            44            44
binop<uint512, uint256, gmp::mul_full>_mean                  +0.0002         +0.0001            35            35            35            35
binop<uint512, uint512, mul_>_mean                           -0.0809         -0.0806            81            74            80            74
binop<uint512, uint512, mul_loop_>_mean                      -0.0470         -0.0473           226           215           224           213
binop<uint512, uint512, mul_loop_opt_>_mean                  -0.1138         -0.1139            67            60            67            59
binop<uint512, uint512, public_mul>_mean                     -0.1153         -0.1157            67            60            67            59
binop<uint512, uint512, gmp::mul>_mean                       +0.0203         +0.0133           105           107           105           106
```

Haswell, GCC10
```
binop<uint256, uint256, mul_>_mean                           +0.0013         +0.0013            10            10            10            10
binop<uint256, uint256, mul_loop_>_mean                      -0.0309         -0.0309            15            14            15            14
binop<uint256, uint256, mul_loop_opt_>_mean                  +0.0811         +0.0811             8             9             8             9
binop<uint256, uint256, public_mul>_mean                     -0.0942         -0.0942            10             9            10             9
binop<uint256, uint256, gmp::mul>_mean                       -0.0007         -0.0007            14            14            14            14
binop<uint512, uint256, umul_>_mean                          +0.0000         +0.0000            19            19            19            19
binop<uint512, uint256, umul_loop_>_mean                     -0.0016         -0.0016            18            18            18            18
binop<uint512, uint256, gmp::mul_full>_mean                  +0.0016         +0.0016            15            15            15            15
binop<uint512, uint512, mul_>_mean                           -0.0759         -0.0759            33            30            33            30
binop<uint512, uint512, mul_loop_>_mean                      -0.0280         -0.0280            96            93            96            93
binop<uint512, uint512, mul_loop_opt_>_mean                  -0.0138         -0.0138            25            25            25            25
binop<uint512, uint512, public_mul>_mean                     -0.0131         -0.0131            25            25            25            25
binop<uint512, uint512, gmp::mul>_mean                       -0.0001         -0.0001            52            52            52            52
```

