### PR TITLE
Change shift amount param from unsigned to uint64_t 

### DIFF
--- a/include/intx/int128.hpp
+++ b/include/intx/int128.hpp
@@ -323,7 +323,7 @@ inline constexpr uint128 operator^(uint128 x, uint128 y) noexcept
     return {x.hi ^ y.hi, x.lo ^ y.lo};
 }
 
-inline constexpr uint128 operator<<(uint128 x, unsigned shift) noexcept
+inline constexpr uint128 operator<<(uint128 x, uint64_t shift) noexcept
 {
     return (shift < 64) ?
                // Find the part moved from lo to hi.
@@ -338,11 +338,11 @@ inline constexpr uint128 operator<<(uint128 x, unsigned shift) noexcept
 inline constexpr uint128 operator<<(uint128 x, uint128 shift) noexcept
 {
     if (shift < 128)
-        return x << unsigned(shift);
+        return x << static_cast<uint64_t>(shift);
     return 0;
 }
 
-inline constexpr uint128 operator>>(uint128 x, unsigned shift) noexcept
+inline constexpr uint128 operator>>(uint128 x, uint64_t shift) noexcept
 {
     return (shift < 64) ?
                // Find the part moved from lo to hi.
@@ -357,7 +357,7 @@ inline constexpr uint128 operator>>(uint128 x, unsigned shift) noexcept
 inline constexpr uint128 operator>>(uint128 x, uint128 shift) noexcept
 {
     if (shift < 128)
-        return x >> unsigned(shift);
+        return x >> static_cast<uint64_t>(shift);
     return 0;
 }
 
@@ -452,12 +452,12 @@ inline constexpr uint128& operator^=(uint128& x, uint128 y) noexcept
     return x = x ^ y;
 }
 
-inline constexpr uint128& operator<<=(uint128& x, unsigned shift) noexcept
+inline constexpr uint128& operator<<=(uint128& x, uint64_t shift) noexcept
 {
     return x = x << shift;
 }
 
-inline constexpr uint128& operator>>=(uint128& x, unsigned shift) noexcept
+inline constexpr uint128& operator>>=(uint128& x, uint64_t shift) noexcept
 {
     return x = x >> shift;
 }

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -341,21 +341,31 @@ TYPED_TEST(uint_test, shift_one_bit)
 {
     for (unsigned shift = 0; shift < sizeof(TypeParam) * 8; ++shift)
     {
-        auto x = TypeParam{1};
-        auto y = x << shift;
-        auto z = y >> shift;
-        EXPECT_EQ(x, z) << "shift: " << shift;
+        SCOPED_TRACE(shift);
+        constexpr auto x = TypeParam{1};
+
+        const auto a = x << shift;
+        const auto b = shl_loop(x, shift);
+        EXPECT_EQ(b, a);
+
+        EXPECT_EQ(x, a >> shift);
     }
 }
 
-TYPED_TEST(uint_test, shift_loop_one_bit)
+TYPED_TEST(uint_test, shift_left_overflow)
 {
-    for (unsigned shift = 0; shift < sizeof(TypeParam) * 8; ++shift)
+    const auto x = ~TypeParam{};
+
+    for (unsigned n = 0; n <= sizeof(TypeParam) * 7; ++n)
     {
-        auto x = TypeParam{1};
-        auto y = shl_loop(x, shift);
-        auto z = y >> shift;
-        EXPECT_EQ(x, z) << "shift: " << shift;
+        const auto sh = x >> n;
+        EXPECT_EQ(x << sh, 0) << "n=" << n;
+    }
+
+    for (unsigned n = 0; n <= sizeof(TypeParam) * 7; ++n)
+    {
+        const auto sh = TypeParam{sizeof(TypeParam) * 8} << n;
+        EXPECT_EQ(x << sh, 0) << "n=" << n;
     }
 }
 
@@ -367,6 +377,7 @@ TYPED_TEST(uint_test, shift_overflow)
     EXPECT_EQ(value >> TypeParam{sh}, 0);
     EXPECT_EQ(value << sh, 0);
     EXPECT_EQ(value << TypeParam{sh}, 0);
+    EXPECT_EQ(shl_loop(value, sh), 0);
 }
 
 TYPED_TEST(uint_test, not_of_zero)

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -371,7 +371,7 @@ TYPED_TEST(uint_test, shift_left_overflow)
 
 TYPED_TEST(uint_test, shift_overflow)
 {
-    unsigned sh = sizeof(TypeParam) * 8;
+    const uint64_t sh = sizeof(TypeParam) * 8;
     const auto value = ~TypeParam{};
     EXPECT_EQ(value >> sh, 0);
     EXPECT_EQ(value >> TypeParam{sh}, 0);


### PR DESCRIPTION
This simplifies reduction from any intx::uint to the shift amount param
because we can just use the lowest word for this.