### PR TITLE
ci: Do not upload clang coverage to codecov

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -170,8 +170,6 @@ jobs:
       - store_artifacts:
           path: ~/build/coverage
           destination: coverage
-      - upload_coverage:
-          flags: clang
 
 
   linux-clang-sanitizers:


### PR DESCRIPTION
The clang coverage after converting to lcov format is not very precise
and causes some false-positive uncovered empty lines for example.