### PR TITLE
Remove sqr()

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -433,16 +433,6 @@ inline constexpr uint<N>& operator-=(uint<N>& x, const T& y) noexcept
 }
 
 template <unsigned N>
-inline constexpr uint<N> sqr(const uint<N>& x) noexcept
-{
-    // Based on recursive multiplication implementation.
-    const auto t = umul(lo(x), lo(x));
-    const auto h = ((lo(x) * hi(x)) << 1) + hi(t);
-    return uint<N>::from_halves(lo(t), h);
-}
-
-
-template <unsigned N>
 inline constexpr uint<2 * N> umul(const uint<N>& x, const uint<N>& y) noexcept
 {
     constexpr auto num_words = uint<N>::num_words;
@@ -484,7 +474,6 @@ inline constexpr uint<N> operator*(const uint<N>& x, const uint<N>& y) noexcept
     return p;
 }
 
-
 template <unsigned N, typename T,
     typename = typename std::enable_if<std::is_convertible<T, uint<N>>::value>::type>
 inline constexpr uint<N>& operator*=(uint<N>& x, const T& y) noexcept
@@ -503,7 +492,7 @@ inline constexpr uint<N> exp(uint<N> base, uint<N> exponent) noexcept
     {
         if ((exponent & 1) != 0)
             result *= base;
-        base = sqr(base);
+        base *= base;
         exponent >>= 1;
     }
     return result;


### PR DESCRIPTION
For `uint256` this is slower than `x * x`. We mostly care about this case only because squaring is used in `exp()`.

I also tried word-based "optimized" `sqr()`
```cpp
inline constexpr uint<256> sqr(const uint<256>& x) noexcept
{
    uint<256> r;
    auto p = umul(x[0], x[0]);
    r[1] = p[1];
    r[0] = p[0];
    p = umul(x[1], x[1]);
    r[3] = p[1];
    r[2] = p[0];

    uint<256> s;

    for (size_t j = 0; j < 2; j++)
    {
        uint64_t k = 0;
        for (size_t i = 1; i < (4 - 2 * j - 1); i++)
        {
            const auto t = umul(x[i], x[j]) + s[i + j] + k;
            s[i + j] = t[0];
            k = t[1];
        }
        s[4 - 1] += x[4 - j - 1] * x[j] + k;
    }

    s = s << 1;

    return r + s;
}
```

Also slower (although should have smaller cost. I believe the shift `<< 1` kills the performance.