### PR TITLE
Enable uint<> of any multiple of 64

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -17,8 +17,8 @@ namespace intx
 template <unsigned N>
 struct uint
 {
-    static_assert((N & (N - 1)) == 0, "Number of bits must be power of 2");
-    static_assert(N >= 256, "Number of bits must be at lest 256");
+    static_assert(N >= 128, "Number of bits must be at lest 128");
+    static_assert(N % 64 == 0, "Number of bits must be a multiply of 64");
 
     using word_type = uint64_t;
 
@@ -73,7 +73,9 @@ public:
     }
 };
 
+using uint192 = uint<192>;
 using uint256 = uint<256>;
+using uint384 = uint<384>;
 using uint512 = uint<512>;
 
 template <unsigned N>

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -4,7 +4,6 @@
 
 #include "test_cases.hpp"
 #include "test_utils.hpp"
-#include <experimental/add.hpp>
 #include <gtest/gtest.h>
 #include <intx/intx.hpp>
 
@@ -195,7 +194,7 @@ class uint_test : public testing::Test
 {
 };
 
-using types = testing::Types<uint128, uint256, uint512>;
+using types = testing::Types<uint128, uint192, uint256, uint384, uint512>;
 TYPED_TEST_SUITE(uint_test, types, type_to_name);
 
 TYPED_TEST(uint_test, numeric_limits)

--- a/test/unittests/test_utils.hpp
+++ b/test/unittests/test_utils.hpp
@@ -25,23 +25,8 @@
 struct type_to_name
 {
     template <typename T>
-    static std::string GetName(int i);
+    static std::string GetName([[maybe_unused]] int i)
+    {
+        return "uint" + std::to_string(T::num_bits);
+    }
 };
-
-template <>
-inline std::string type_to_name::GetName<intx::uint<128>>(int)
-{
-    return "uint128";
-}
-
-template <>
-inline std::string type_to_name::GetName<intx::uint<256>>(int)
-{
-    return "uint256";
-}
-
-template <>
-inline std::string type_to_name::GetName<intx::uint<512>>(int)
-{
-    return "uint512";
-}


### PR DESCRIPTION
Allow constructing uint type for any number of 64-bit words.
This also enables basic tests for uint192 and uint384 types.