### PR TITLE
Restore previous less-than implementation for uint256

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -118,6 +118,14 @@ inline constexpr bool operator!=(const T& x, const uint<N>& y) noexcept
     return uint<N>(x) != y;
 }
 
+inline constexpr bool operator<(const uint256& x, const uint256& y) noexcept
+{
+    const auto xhi = uint128{x[2], x[3]};
+    const auto xlo = uint128{x[0], x[1]};
+    const auto yhi = uint128{y[2], y[3]};
+    const auto ylo = uint128{y[0], y[1]};
+    return (xhi < yhi) | ((xhi == yhi) & (xlo < ylo));
+}
 
 template <unsigned N>
 inline constexpr bool operator<(const uint<N>& x, const uint<N>& y) noexcept

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -143,7 +143,7 @@ inline constexpr bool operator<(const T& x, const uint<N>& y) noexcept
 template <unsigned N>
 inline constexpr bool operator>(const uint<N>& x, const uint<N>& y) noexcept
 {
-    return sub_with_carry(y, x).carry;
+    return y < x;
 }
 
 template <unsigned N, typename T,
@@ -164,7 +164,7 @@ inline constexpr bool operator>(const T& x, const uint<N>& y) noexcept
 template <unsigned N>
 inline constexpr bool operator>=(const uint<N>& x, const uint<N>& y) noexcept
 {
-    return !sub_with_carry(x, y).carry;
+    return !(x < y);
 }
 
 template <unsigned N, typename T,
@@ -185,7 +185,7 @@ inline constexpr bool operator>=(const T& x, const uint<N>& y) noexcept
 template <unsigned N>
 inline constexpr bool operator<=(const uint<N>& x, const uint<N>& y) noexcept
 {
-    return !sub_with_carry(y, x).carry;
+    return !(y < x);
 }
 
 template <unsigned N, typename T,

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -118,6 +118,7 @@ inline constexpr bool operator!=(const T& x, const uint<N>& y) noexcept
     return uint<N>(x) != y;
 }
 
+#if !defined(_MSC_VER) || _MSC_VER < 1916  // This kills MSVC 2017 compiler.
 inline constexpr bool operator<(const uint256& x, const uint256& y) noexcept
 {
     const auto xhi = uint128{x[2], x[3]};
@@ -126,6 +127,7 @@ inline constexpr bool operator<(const uint256& x, const uint256& y) noexcept
     const auto ylo = uint128{y[0], y[1]};
     return (xhi < yhi) | ((xhi == yhi) & (xlo < ylo));
 }
+#endif
 
 template <unsigned N>
 inline constexpr bool operator<(const uint<N>& x, const uint<N>& y) noexcept


### PR DESCRIPTION
```
Comparing o/lt-old to o/lt-new
Benchmark                                        Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------------------
compare<lt_public>/64_mean                    -0.1253         -0.1254             3             3             3             3
compare<lt_public>/128_mean                   -0.1269         -0.1269             3             3             3             3
compare<lt_public>/192_mean                   -0.1253         -0.1253             3             3             3             3
compare<lt_public>/256_mean                   -0.1262         -0.1262             3             3             3             3
```