### PR TITLE
addc/subc optimizations

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -2033,17 +2033,25 @@ inline uint256 addmod(const uint256& x, const uint256& y, const uint256& mod) no
     // Based on https://github.com/holiman/uint256/pull/86.
     if ((mod[3] != 0) && (x[3] <= mod[3]) && (y[3] <= mod[3]))
     {
-        auto s = subc(x, mod);
-        if (s.carry)
-            s.value = x;
+        // Normalize x in case it is bigger than mod.
+        auto xn = x;
+        const auto xd = subc(x, mod);
+        if (!xd.carry)
+            xn = xd.value;
 
-        auto t = subc(y, mod);
-        if (t.carry)
-            t.value = y;
+        // Normalize y in case it is bigger than mod.
+        auto yn = y;
+        const auto yd = subc(y, mod);
+        if (!yd.carry)
+            yn = yd.value;
 
-        s = addc(s.value, t.value);
-        t = subc(s.value, mod);
-        return (s.carry || !t.carry) ? t.value : s.value;
+        const auto a = addc(xn, yn);
+        const auto av = a.value;
+        const auto b = subc(av, mod);
+        const auto bv = b.value;
+        if (a.carry || !b.carry)
+            return bv;
+        return av;
     }
 
     const auto s = addc(x, y);

--- a/test/benchmarks/benchmarks.cpp
+++ b/test/benchmarks/benchmarks.cpp
@@ -94,7 +94,8 @@ BENCHMARK_TEMPLATE(mod, addmod)->ARGS;
 BENCHMARK_TEMPLATE(mod, addmod_public)->ARGS;
 BENCHMARK_TEMPLATE(mod, addmod_simple)->ARGS;
 BENCHMARK_TEMPLATE(mod, addmod_prenormalize)->ARGS;
-BENCHMARK_TEMPLATE(mod, addmod_daosvik)->ARGS;
+BENCHMARK_TEMPLATE(mod, addmod_daosvik_v1)->ARGS;
+BENCHMARK_TEMPLATE(mod, addmod_daosvik_v2)->ARGS;
 BENCHMARK_TEMPLATE(mod, mulmod)->ARGS;
 #undef ARGS
 
@@ -118,7 +119,8 @@ static void ecmod(benchmark::State& state)
 BENCHMARK_TEMPLATE(ecmod, addmod_public);
 BENCHMARK_TEMPLATE(ecmod, addmod_simple);
 BENCHMARK_TEMPLATE(ecmod, addmod_prenormalize);
-BENCHMARK_TEMPLATE(ecmod, addmod_daosvik);
+BENCHMARK_TEMPLATE(ecmod, addmod_daosvik_v1);
+BENCHMARK_TEMPLATE(ecmod, addmod_daosvik_v2);
 BENCHMARK_TEMPLATE(ecmod, mulmod);
 
 

--- a/test/fuzzer/opmod_fuzz.cpp
+++ b/test/fuzzer/opmod_fuzz.cpp
@@ -32,7 +32,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t data_size) noe
         intx::test::addmod_public,
         intx::test::addmod_simple,
         intx::test::addmod_prenormalize,
-        intx::test::addmod_daosvik,
+        intx::test::addmod_daosvik_v1,
+        intx::test::addmod_daosvik_v2,
     };
 
     if (data_size < input_size)

--- a/test/unittests/test_builtins.cpp
+++ b/test/unittests/test_builtins.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 #include <intx/intx.hpp>
 
+#pragma warning(disable : 4307)
+
 using namespace intx;
 
 static_assert(clz_generic(uint32_t{0}) == 32);
@@ -28,6 +30,16 @@ static_assert(to_big_endian(uint16_t{0x0b0a}) == (is_le ? 0x0a0b : 0x0b0a));
 static_assert(to_big_endian(uint32_t{0x0d0c0b0a}) == (is_le ? 0x0a0b0c0d : 0x0d0c0b0a));
 static_assert(to_big_endian(uint64_t{0x02010f0e0d0c0b0a}) ==
               (is_le ? 0x0a0b0c0d0e0f0102 : 0x02010f0e0d0c0b0a));
+
+static_assert(addc(0, 0).value == 0);
+static_assert(!addc(0, 0).carry);
+static_assert(addc(0xffffffffffffffff, 2).value == 1);
+static_assert(addc(0xffffffffffffffff, 2).carry);
+
+static_assert(subc(0, 0).value == 0);
+static_assert(!subc(0, 0).carry);
+static_assert(subc(0, 1).value == 0xffffffffffffffff);
+static_assert(subc(0, 1).carry);
 
 
 TEST(builtins, clz64_single_one)

--- a/test/unittests/test_uint256.cpp
+++ b/test/unittests/test_uint256.cpp
@@ -170,7 +170,8 @@ static decltype(&addmod) addmod_impls[] = {
     test::addmod_public,
     test::addmod_simple,
     test::addmod_prenormalize,
-    test::addmod_daosvik,
+    test::addmod_daosvik_v1,
+    test::addmod_daosvik_v2,
 };
 
 TEST(uint256, addmod)


### PR DESCRIPTION
Use compiler builtins to implement `addc` and `subc` primitives. This mostly benefits GCC (clang is able to match respective patterns without builtins).