### PR TITLE
Add big-endian support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,14 @@ commands:
             sudo apt -q update
             sudo apt install -qy libgmp-dev
 
+  install_powerpc64:
+    steps:
+      - run:
+          name: "Install powerpc64 toolchain"
+          command: |
+            sudo apt -q update
+            sudo apt -qy install g++-powerpc64-linux-gnu qemu-user-static
+
   check_code_format:
     steps:
       - run:
@@ -195,6 +203,15 @@ jobs:
       - build_and_test
       - benchmark
 
+  powerpc64:
+    environment:
+      BUILD_TYPE: Release
+      CMAKE_OPTIONS: -DCMAKE_TOOLCHAIN_FILE=~/project/cmake/toolchains/powerpc64.cmake -DINTX_BENCHMARKING=OFF
+    executor: linux-gcc-latest
+    steps:
+      - install_powerpc64
+      - build_and_test
+
   arm64:
     environment:
       BUILD_TYPE: Release
@@ -299,3 +316,4 @@ workflows:
       - macos
       - cmake-min
       - arm64
+      - powerpc64

--- a/cmake/toolchains/powerpc64.cmake
+++ b/cmake/toolchains/powerpc64.cmake
@@ -1,0 +1,15 @@
+# Cable: CMake Bootstrap Library.
+# Copyright 2018 Pawel Bylica.
+# Licensed under the Apache License, Version 2.0. See the LICENSE file.
+
+set(CMAKE_SYSTEM_PROCESSOR powerpc64)
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_C_COMPILER powerpc64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER powerpc64-linux-gnu-g++)
+
+set(CMAKE_FIND_ROOT_PATH /usr/powerpc64-linux-gnu)
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_CROSSCOMPILING_EMULATOR qemu-ppc64-static;-L;${CMAKE_FIND_ROOT_PATH})

--- a/test/unittests/test_builtins.cpp
+++ b/test/unittests/test_builtins.cpp
@@ -17,6 +17,18 @@ static_assert(clz_generic(uint64_t{1}) == 63);
 static_assert(clz_generic(uint64_t{3}) == 62);
 static_assert(clz_generic(uint64_t{9}) == 60);
 
+static constexpr auto is_le = byte_order_is_little_endian;
+static_assert(to_little_endian(uint8_t{0x0a}) == 0x0a);
+static_assert(to_little_endian(uint16_t{0x0b0a}) == (is_le ? 0x0b0a : 0x0a0b));
+static_assert(to_little_endian(uint32_t{0x0d0c0b0a}) == (is_le ? 0x0d0c0b0a : 0x0a0b0c0d));
+static_assert(to_little_endian(uint64_t{0x02010f0e0d0c0b0a}) ==
+              (is_le ? 0x02010f0e0d0c0b0a : 0x0a0b0c0d0e0f0102));
+static_assert(to_big_endian(uint8_t{0x0a}) == 0x0a);
+static_assert(to_big_endian(uint16_t{0x0b0a}) == (is_le ? 0x0a0b : 0x0b0a));
+static_assert(to_big_endian(uint32_t{0x0d0c0b0a}) == (is_le ? 0x0a0b0c0d : 0x0d0c0b0a));
+static_assert(to_big_endian(uint64_t{0x02010f0e0d0c0b0a}) ==
+              (is_le ? 0x0a0b0c0d0e0f0102 : 0x02010f0e0d0c0b0a));
+
 
 TEST(builtins, clz64_single_one)
 {

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -272,7 +272,7 @@ TYPED_TEST(uint_test, to_string_base)
 
 TYPED_TEST(uint_test, as_bytes)
 {
-    constexpr auto x = TypeParam{0xa05};
+    constexpr auto x = to_little_endian(TypeParam{0xa05});
     const auto b = as_bytes(x);
     EXPECT_EQ(b[0], 5);
     EXPECT_EQ(b[1], 0xa);
@@ -281,5 +281,6 @@ TYPED_TEST(uint_test, as_bytes)
     auto d = as_bytes(y);
     d[0] = 3;
     d[1] = 0xc;
+    y = to_little_endian(y);
     EXPECT_EQ(y, 0xc03);
 }


### PR DESCRIPTION
Add to_little_endian()/to_big_endian() helpers converting internal representations to/from requested byte order.
Also fix store()/load() functions to work correctly on big-endian architectures.