### PR TITLE
Optimize BE load and store of uint256

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -2074,6 +2074,25 @@ inline void store(uint8_t* dst, const T& x) noexcept
     const auto d = to_big_endian(x);
     std::memcpy(dst, &d, sizeof(d));
 }
+
+/// Specialization for uint256.
+inline void store(uint8_t* dst, const uint256& x) noexcept
+{
+    // Store byte-swapped words in primitive temporaries. This helps with memory aliasing
+    // and GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107837
+    // TODO: Use std::byte instead of uint8_t.
+    const auto v0 = to_big_endian(x[0]);
+    const auto v1 = to_big_endian(x[1]);
+    const auto v2 = to_big_endian(x[2]);
+    const auto v3 = to_big_endian(x[3]);
+
+    // Store words in reverse (big-endian) order, write addresses are ascending.
+    std::memcpy(dst, &v3, sizeof(v3));
+    std::memcpy(dst + 8, &v2, sizeof(v2));
+    std::memcpy(dst + 16, &v1, sizeof(v1));
+    std::memcpy(dst + 24, &v0, sizeof(v0));
+}
+
 }  // namespace unsafe
 
 }  // namespace be

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1832,6 +1832,11 @@ inline constexpr div_result<uint<N>> sdivrem(const uint<N>& u, const uint<N>& v)
     return {q_is_neg ? -res.quot : res.quot, u_is_neg ? -res.rem : res.rem};
 }
 
+inline constexpr uint256 bswap(const uint256& x) noexcept
+{
+    return {bswap(x[3]), bswap(x[2]), bswap(x[1]), bswap(x[0])};
+}
+
 template <unsigned N>
 inline constexpr uint<N> bswap(const uint<N>& x) noexcept
 {

--- a/test/benchmarks/benchmarks.cpp
+++ b/test/benchmarks/benchmarks.cpp
@@ -562,4 +562,35 @@ BENCHMARK_TEMPLATE(to_string, uint128);
 BENCHMARK_TEMPLATE(to_string, uint256);
 BENCHMARK_TEMPLATE(to_string, uint512);
 
+
+template <typename Int>
+[[gnu::noinline]] auto load_be(const uint8_t* data) noexcept
+{
+    return intx::be::unsafe::load<Int>(data);
+}
+
+template <typename Int>
+[[gnu::noinline]] auto store_be(uint8_t* data, const Int& v) noexcept
+{
+    intx::be::unsafe::store(data, v);
+}
+
+template <typename Int>
+static void load_store_be(benchmark::State& state)
+{
+    uint8_t load_buffer[sizeof(Int) + 7]{};
+    const auto unaligned_load_ptr = load_buffer + 7;
+    uint8_t store_buffer[sizeof(Int) + 1]{};
+    const auto unaligned_store_ptr = store_buffer + 1;
+
+    for ([[maybe_unused]] auto _ : state)
+    {
+        auto v = load_be<Int>(unaligned_load_ptr);
+        store_be(unaligned_store_ptr, v);
+    }
+}
+BENCHMARK_TEMPLATE(load_store_be, uint128);
+BENCHMARK_TEMPLATE(load_store_be, uint256);
+BENCHMARK_TEMPLATE(load_store_be, uint512);
+
 BENCHMARK_MAIN();

--- a/test/unittests/test_intx.cpp
+++ b/test/unittests/test_intx.cpp
@@ -154,7 +154,7 @@ TYPED_TEST(uint_test, endianness)
 
 TYPED_TEST(uint_test, be_zext)
 {
-    uint8_t data[] = {0x01, 0x02, 0x03};
+    const uint8_t data[] = {0x01, 0x02, 0x03};
     const auto x = be::load<TypeParam>(data);
     EXPECT_EQ(x, 0x010203);
 }
@@ -164,9 +164,9 @@ TYPED_TEST(uint_test, be_load)
     constexpr auto size = sizeof(TypeParam);
     uint8_t data[size]{};
     data[0] = 0x80;
-    data[size - 1] = 1;
+    data[size - 1] = 3;
     const auto x = be::load<TypeParam>(data);
-    EXPECT_EQ(x, (TypeParam{1} << (TypeParam::num_bits - 1)) | 1);
+    EXPECT_EQ(x, (TypeParam{1} << (TypeParam::num_bits - 1)) | 3);
 }
 
 TYPED_TEST(uint_test, be_store)


### PR DESCRIPTION
This is critical for EVM `MSTORE` and `MLOAD`. GCC was not properly optimizing these because of the https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107837 bug.

```
load_store_be<uint128>_mean                  +0.0115         +0.0114             2             2             2             2
load_store_be<uint256>_mean                  -0.8506         -0.8506            23             3            23             3
load_store_be<uint512>_mean                  -0.4334         -0.4335            40            23            40            23
```