### PR TITLE
Enable 32-bit Windows build in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  win: circleci/windows@5.0
 
 executors:
   linux-gcc-latest:
@@ -287,6 +289,38 @@ jobs:
       - build_and_test
       - benchmark
 
+  windows-32bit:
+    executor: win/server-2022
+    steps:
+      - checkout
+      - run:
+          name: "Setup environment (bash)"
+          shell: bash
+          command: |
+            echo 'export PATH=$PATH:"/c/Program Files/Microsoft Visual Studio/2022/Community/Common7/IDE/CommonExtensions/Microsoft/CMake/CMake/bin"' >> $BASH_ENV
+      - run:
+          name: 'Configure'
+          shell: powershell
+          command: |
+            $ErrorActionPreference = "Stop"
+            & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1' -Arch x86
+            which cmake
+            cmake -S . -B ~/build -G Ninja -DCMAKE_INSTALL_PREFIX=C:\install -DCMAKE_BUILD_TYPE=Release -DINTX_BENCHMARKING=OFF
+      - run:
+          name: 'Build'
+          shell: powershell
+          command: |
+            $ErrorActionPreference = "Stop"
+            & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1' -Arch x86
+            cmake --build ~/build
+      - run:
+          name: 'Test'
+          shell: powershell
+          working_directory: ~/build
+          command: |
+            $ErrorActionPreference = "Stop"
+            & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1' -Arch x86
+            ctest -j4 --output-on-failure --schedule-random
 
   cmake-min:
     docker:
@@ -312,3 +346,4 @@ workflows:
       - cmake-min
       - arm64
       - powerpc64
+      - windows-32bit

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -440,7 +440,7 @@ inline constexpr uint128 umul(uint64_t x, uint64_t y) noexcept
 {
 #if INTX_HAS_BUILTIN_INT128
     return builtin_uint128{x} * builtin_uint128{y};
-#elif defined(_MSC_VER) && _MSC_VER >= 1925
+#elif defined(_MSC_VER) && _MSC_VER >= 1925 && defined(_M_X64)
     if (!is_constant_evaluated())
     {
         unsigned __int64 hi = 0;


### PR DESCRIPTION
This fixes a build failure. [`_umul128` is x64 only](https://learn.microsoft.com/en-us/cpp/intrinsics/umul128?view=msvc-170), so [using `_M_X64`](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170) for checking that.