### PR TITLE
cmake: Update compiler settings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,6 +36,7 @@ Checks: >
   hicpp-multiway-paths-covered,
   hicpp-no-assembler,
   misc-*,
+  -misc-const-correctness,
   -misc-non-private-member-variables-in-classes,
   modernize-*,
   -modernize-avoid-c-arrays,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2019 Pawel Bylica.
 # Licensed under the Apache License, Version 2.0.
 
-cmake_minimum_required(VERSION 3.16...3.23)
+cmake_minimum_required(VERSION 3.16...3.25)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ install:
 before_build:
   - if "%VS_VER%" == "2022" (call "%ProgramFiles%\Microsoft Visual Studio\%VS_VER%\Community\Common7\Tools\vsdevcmd" -arch=amd64)
   - if not "%VS_VER%" == "2022" (call "%ProgramFiles(x86)%\Microsoft Visual Studio\%VS_VER%\Community\Common7\Tools\vsdevcmd" -arch=amd64)
-  - cmake -S . -B build -DINTX_BENCHMARKING=OFF -DNATIVE=ON -Wno-dev -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DHUNTER_CONFIGURATION_TYPES=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=C:\install
+  - cmake -S . -B build -DINTX_BENCHMARKING=OFF -DNATIVE=ON -Wno-dev -G "%GENERATOR%" -DCMAKE_COMPILE_WARNING_AS_ERROR=TRUE -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DHUNTER_CONFIGURATION_TYPES=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX=C:\install
 
 build_script:
   - cmake --build build --target install --parallel 1

--- a/circle.yml
+++ b/circle.yml
@@ -5,10 +5,10 @@ orbs:
 executors:
   linux-gcc-latest:
     docker:
-      - image: ethereum/cpp-build-env:18-gcc-12
+      - image: ethereum/cpp-build-env:19-gcc-12
   linux-clang-latest:
     docker:
-      - image: ethereum/cpp-build-env:18-clang-14
+      - image: ethereum/cpp-build-env:19-clang-15
   macos:
     macos:
       xcode: 14.2.0
@@ -56,7 +56,7 @@ commands:
       - checkout
       - run:
           name: "Configure"
-          command: cmake -B ~/build -DCMAKE_INSTALL_PREFIX=~/install -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_OPTIONS
+          command: cmake -B ~/build -DCMAKE_COMPILE_WARNING_AS_ERROR=TRUE -DCMAKE_INSTALL_PREFIX=~/install -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_OPTIONS
       - run:
           name: "Build"
           command: |
@@ -101,8 +101,8 @@ commands:
         type: string
     steps:
       - run:
-          name: "Upgrade codecov"
-          command: sudo pip3 install --upgrade --quiet --no-cache-dir codecov
+          name: "Install codecov"
+          command: pip3 install --break-system-packages --upgrade --user --quiet --no-cache-dir codecov
       - run:
           name: "Upload to Codecov"
           command: |
@@ -121,8 +121,7 @@ jobs:
 
   lint:
     docker:
-      # TODO: clang-format-14 has a regression. Jump to 15 when available.
-      - image: ethereum/cpp-build-env:17-clang-13
+      - image: ethereum/cpp-build-env:19-clang-15
     steps:
       - checkout
       - check_code_format
@@ -134,7 +133,7 @@ jobs:
       - run:
           name: "Build package"
           command: |
-            cmake -B ~/build -DINTX_TESTING=OFF
+            cmake -B ~/build -DCMAKE_COMPILE_WARNING_AS_ERROR=TRUE -DINTX_TESTING=OFF
             cmake --build ~/build --target package
       - run:
           name: "Inspect package"
@@ -236,7 +235,7 @@ jobs:
       BUILD_TYPE: Release
       CMAKE_OPTIONS: -DCMAKE_TOOLCHAIN_FILE=~/project/cmake/toolchains/32bit.cmake -DINTX_BENCHMARKING=OFF
     docker:
-      - image: ethereum/cpp-build-env:18-gcc-12-multilib
+      - image: ethereum/cpp-build-env:19-gcc-12-multilib
     steps:
       - build_and_test
 
@@ -247,7 +246,7 @@ jobs:
       TESTS_FILTER: unittests
       TESTS_EXCLUDE: random
     docker:
-      - image: ethereum/cpp-build-env:18-gcc-12-multilib
+      - image: ethereum/cpp-build-env:19-gcc-12-multilib
     steps:
       - build_and_test
       - collect_coverage_gcc
@@ -304,8 +303,8 @@ jobs:
           command: |
             $ErrorActionPreference = "Stop"
             & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1' -Arch x86
-            which cmake
-            cmake -S . -B ~/build -G Ninja -DCMAKE_INSTALL_PREFIX=C:\install -DCMAKE_BUILD_TYPE=Release -DINTX_BENCHMARKING=OFF
+            cmake --version
+            cmake -S . -B ~/build -G Ninja -DCMAKE_COMPILE_WARNING_AS_ERROR=TRUE -DCMAKE_INSTALL_PREFIX=C:\install -DCMAKE_BUILD_TYPE=Release -DINTX_BENCHMARKING=OFF
       - run:
           name: 'Build'
           shell: powershell

--- a/cmake/CableCompilerSettings.cmake
+++ b/cmake/CableCompilerSettings.cmake
@@ -1,13 +1,22 @@
 # Cable: CMake Bootstrap Library <https://github.com/ethereum/cable>
-# Copyright 2018-2020 Pawel Bylica.
+# Copyright 2018 Pawel Bylica.
 # Licensed under the Apache License, Version 2.0.
 
-# Cable Compiler Settings, version 1.0.1
+# Cable Compiler Settings, version 1.2.0
 #
 # This CMake module provides default configuration (with some options)
 # for C/C++ compilers. Use cable_configure_compiler().
 #
 # CHANGELOG
+#
+# 1.2.0 - 2023-02-25
+# - Do not set -Werror nor /WX. This has been standardized in CMake 3.24 as CMAKE_COMPILE_WARNING_AS_ERROR.
+# - Keep compiler warnings about unknown pragmas.
+# - Keep MSVC warning C5030: attribute is not recognized. It should be disabled in source code.
+# - Do not try to erase MSVC default warning level /W3. This is not set since CMake 3.15 (CMP0092).
+# - Drop explicit -Wimplicit-fallthrough. It is a part of -Wextra.
+# - Use PROJECT_IS_TOP_LEVEL if available (or define it).
+# - Use include_guard().
 #
 # 1.1.0 - 2020-06-20
 # - Allow unknown C++ attributes in MSVC compiler.
@@ -19,11 +28,7 @@
 #
 # 1.0.0 - 2019-12-20
 
-if(cable_compiler_settings_included)
-    return()
-endif()
-set(cable_compiler_settings_included TRUE)
-
+include_guard()
 include(CheckCXXCompilerFlag)
 
 # Adds CXX compiler flag if the flag is supported by the compiler.
@@ -55,15 +60,13 @@ macro(cable_configure_compiler)
         message(FATAL_ERROR "cable_configure_compiler() must be used after project()")
     endif()
 
-    # Determine if this is the main or a subproject. Leave this variable available for later use.
-    if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-        set(PROJECT_IS_MAIN TRUE)
-    else()
-        set(PROJECT_IS_MAIN FALSE)
+    if(NOT DEFINED PROJECT_IS_TOP_LEVEL)
+        # Define PROJECT_IS_TOP_LEVEL (since CMake 3.21) if not available.
+        string(COMPARE EQUAL ${CMAKE_SOURCE_DIR} ${PROJECT_SOURCE_DIR} PROJECT_IS_TOP_LEVEL)
     endif()
 
-    if(PROJECT_IS_MAIN)
-        # Do this configuration only in the main project.
+    if(PROJECT_IS_TOP_LEVEL)
+        # Do this configuration only in the top level project.
 
         cmake_parse_arguments(cable "NO_CONVERSION_WARNINGS;NO_STACK_PROTECTION;NO_PEDANTIC" "" "" ${ARGN})
 
@@ -89,16 +92,13 @@ macro(cable_configure_compiler)
                 add_compile_options(-Wpedantic)
             endif()
 
-            # Enable basing warnings set and treat them as errors.
-            add_compile_options(-Werror -Wall -Wextra -Wshadow)
+            # Enable basic warnings.
+            add_compile_options(-Wall -Wextra -Wshadow)
 
             if(NOT cable_NO_CONVERSION_WARNINGS)
                 # Enable conversion warnings if not explicitly disabled.
                 add_compile_options(-Wconversion -Wsign-conversion)
             endif()
-
-            # Allow unknown pragmas, we don't want to wrap them with #ifdefs.
-            add_compile_options(-Wno-unknown-pragmas)
 
             # Stack protection.
             check_cxx_compiler_flag(-fstack-protector fstack-protector)
@@ -118,22 +118,10 @@ macro(cable_configure_compiler)
                 endif()
             endif()
 
-            cable_add_cxx_compiler_flag_if_supported(-Wimplicit-fallthrough)
-
         elseif(MSVC)
 
-            # Get rid of default warning level.
-            string(REPLACE " /W3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-            string(REPLACE " /W3" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-
-            # Enable basing warnings set and treat them as errors.
-            add_compile_options(/W4 /WX)
-
-            # Allow unknown pragmas, we don't want to wrap them with #ifdefs.
-            add_compile_options(/wd4068)
-
-            # Allow unknown C++ attributes.
-            add_compile_options(/wd5030)
+            # Enable basic warnings.
+            add_compile_options(/W4)
 
         endif()
 

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -875,7 +875,7 @@ inline uint128& operator%=(uint128& x, uint128 y) noexcept
 namespace std
 {
 template <unsigned N>
-struct numeric_limits<intx::uint<N>>
+struct numeric_limits<intx::uint<N>>  // NOLINT(cert-dcl58-cpp)
 {
     using type = intx::uint<N>;
 

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -15,6 +15,12 @@
 #include <tuple>
 #include <type_traits>
 
+#ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable : 5030)  // Allow unknown attributes.
+#endif
+
+
 #ifndef __has_builtin
     #define __has_builtin(NAME) 0
 #endif
@@ -2098,3 +2104,7 @@ inline void store(uint8_t* dst, const uint256& x) noexcept
 }  // namespace be
 
 }  // namespace intx
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,10 +2,11 @@
 # Copyright 2019 Pawel Bylica.
 # Licensed under the Apache License, Version 2.0.
 
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
-    add_subdirectory(analysis)
-endif()
+add_compile_options(
+    $<$<CXX_COMPILER_ID:MSVC>:-wd5030>  # allow unknown attributes
+)
 
+add_subdirectory(analysis)
 add_subdirectory(experimental)
 add_subdirectory(utils)
 add_subdirectory(integration)

--- a/test/unittests/test_builtins.cpp
+++ b/test/unittests/test_builtins.cpp
@@ -5,8 +5,6 @@
 #include <gtest/gtest.h>
 #include <intx/intx.hpp>
 
-#pragma warning(disable : 4307)
-
 using namespace intx;
 
 static_assert(clz_generic(uint32_t{0}) == 32);

--- a/test/unittests/test_int128.cpp
+++ b/test/unittests/test_int128.cpp
@@ -4,8 +4,6 @@
 
 #include "test_suite.hpp"
 
-#pragma warning(disable : 4307)
-
 using namespace intx;
 
 namespace

--- a/test/unittests/test_intx_api.cpp
+++ b/test/unittests/test_intx_api.cpp
@@ -4,8 +4,6 @@
 
 #include "test_suite.hpp"
 
-#pragma warning(disable : 4307)
-
 using namespace intx;
 
 static_assert(uint128{2} + uint128{2} == 4);


### PR DESCRIPTION
Update compiler settings. Disable some warnings in intx.hpp source, not in CMake so it is easier to use a copy of intx.hpp in other projects.

Fixes #285.