### PR TITLE
Fix buggy __builtin_subcll in Xcode 14.3.1 on arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Documentation of all notable changes to the **intx** project.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [0.9.3] — unreleased
+
+### Fixed
+
+- Fixed buggy `__builtin_subcll` in Xcode 14.3.1 on arm64.
+  [294](https://github.com/chfast/intx/pull/294)
+
 ## [0.9.2] — 2023-03-11
 
 ### Changed
@@ -179,6 +186,7 @@ and this project adheres to [Semantic Versioning].
   [#99](https://github.com/chfast/intx/pull/99)
 
 
+[0.9.3]: https://github.com/chfast/intx/compare/v0.9.2..release/0.9
 [0.9.2]: https://github.com/chfast/intx/releases/v0.9.2
 [0.9.1]: https://github.com/chfast/intx/releases/v0.9.1
 [0.9.0]: https://github.com/chfast/intx/releases/v0.9.0

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -202,7 +202,8 @@ inline constexpr result_with_carry<uint64_t> addc(
 inline constexpr result_with_carry<uint64_t> subc(
     uint64_t x, uint64_t y, bool carry = false) noexcept
 {
-#if __has_builtin(__builtin_subcll)
+    // Use __builtin_subcll if available (except buggy Xcode 14.3.1 on arm64).
+#if __has_builtin(__builtin_subcll) && __apple_build_version__ != 14030022
     if (!is_constant_evaluated())
     {
         unsigned long long carryout = 0;  // NOLINT(google-runtime-int)


### PR DESCRIPTION
The C++ compiler from Xcode 14.3.1 miscompiles __builtin_subcll on arm64 / Apple M1 architectures.
This change disables usage of the builtin in this compiler version.

Replaces #293.
Fixes #292.