### PR TITLE
Fix division of numerator 0

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1582,8 +1582,8 @@ template <unsigned M, unsigned N>
         na.divisor = denominator;
     }
 
-    // Skip the highest word of numerator if not significant.
-    if (un[m] != 0 || un[m - 1] >= vn[n - 1])
+    // Add the highest word of the normalized numerator if significant.
+    if (m != 0 && (un[m] != 0 || un[m - 1] >= vn[n - 1]))
         ++m;
 
     return na;


### PR DESCRIPTION
In case the division numerator is 0 its computed number of words `m` is also 0. Then avoid accessing `un[m-1]`.

This is not a critical bug because in the worst case we increased the `m` by 1 but results were computed correctly.