### PR TITLE
cmake: Force MSVC standards conformance mode

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 add_compile_options(
     $<$<CXX_COMPILER_ID:MSVC>:-wd5030>  # allow unknown attributes
+    $<$<CXX_COMPILER_ID:MSVC>:-permissive->  # standards conformance
+    $<$<CXX_COMPILER_ID:MSVC>:-Zc:preprocessor>  # preprocessor conformance mode
 
     # prevent gtest build failure on 32-bit arch
     $<$<AND:$<CXX_COMPILER_ID:GNU>,$<EQUAL:${CMAKE_SIZEOF_VOID_P},4>>:-Wno-restrict>


### PR DESCRIPTION
Enable `-Zc:preprocessor` and `-permissive-` compiler flags when testing MSVC builds. 