### PR TITLE
Add support for c++20 spaceship operator <=>

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -312,7 +312,10 @@ public:
     friend constexpr bool operator<=(uint x, uint y) noexcept { return !(y < x); }
     friend constexpr bool operator>(uint x, uint y) noexcept { return y < x; }
     friend constexpr bool operator>=(uint x, uint y) noexcept { return !(x < y); }
-    friend constexpr short operator<=>(uint x, uint y) noexcept { return (x < y) ? -1 : (y < x) ? 1 : 0; }
+    friend constexpr int8_t operator<=>(uint x, uint y) noexcept
+    {
+        return (x < y) ? -1 : (y < x) ? 1 : 0;
+    }
 
     friend constexpr uint operator~(uint x) noexcept { return {~x[0], ~x[1]}; }
     friend constexpr uint operator|(uint x, uint y) noexcept { return {x[0] | y[0], x[1] | y[1]}; }
@@ -1013,7 +1016,10 @@ public:
     friend constexpr bool operator>(const uint& x, const uint& y) noexcept { return y < x; }
     friend constexpr bool operator>=(const uint& x, const uint& y) noexcept { return !(x < y); }
     friend constexpr bool operator<=(const uint& x, const uint& y) noexcept { return !(y < x); }
-    friend constexpr short operator<=>(const uint& x, const uint&y) noexcept { return x < y ? -1 : x == y ? 0 : 1; }
+    friend constexpr int8_t operator<=>(const uint& x, const uint&y) noexcept
+    {
+        return x < y ? -1 : x == y ? 0 : 1;
+    }
 
     friend inline constexpr uint operator<<(const uint& x, uint64_t shift) noexcept
     {

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -310,9 +310,16 @@ public:
     friend constexpr bool operator<=(uint x, uint y) noexcept { return !(y < x); }
     friend constexpr bool operator>(uint x, uint y) noexcept { return y < x; }
     friend constexpr bool operator>=(uint x, uint y) noexcept { return !(x < y); }
-    friend constexpr int operator<=>(uint x, uint y) noexcept
+
+    friend constexpr std::strong_ordering operator<=>(uint x, uint y) noexcept
     {
-        return (x < y) ? -1 : (y < x) ? 1 : 0;
+        if (x < y)
+            return std::strong_ordering::less;
+
+        if (x > y)
+            return std::strong_ordering::greater;
+
+        return std::strong_ordering::equal;
     }
 
     friend constexpr uint operator~(uint x) noexcept { return {~x[0], ~x[1]}; }
@@ -1028,9 +1035,16 @@ public:
     friend constexpr bool operator>(const uint& x, const uint& y) noexcept { return y < x; }
     friend constexpr bool operator>=(const uint& x, const uint& y) noexcept { return !(x < y); }
     friend constexpr bool operator<=(const uint& x, const uint& y) noexcept { return !(y < x); }
-    friend constexpr int operator<=>(const uint& x, const uint& y) noexcept
+
+    friend constexpr std::strong_ordering operator<=>(const uint& x, const uint& y) noexcept
     {
-        return x < y ? -1 : x == y ? 0 : 1;
+        if (x < y)
+            return std::strong_ordering::less;
+
+        if (x > y)
+            return std::strong_ordering::greater;
+
+        return std::strong_ordering::equal;
     }
 
     friend constexpr uint operator<<(const uint& x, uint64_t shift) noexcept

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -312,6 +312,7 @@ public:
     friend constexpr bool operator<=(uint x, uint y) noexcept { return !(y < x); }
     friend constexpr bool operator>(uint x, uint y) noexcept { return y < x; }
     friend constexpr bool operator>=(uint x, uint y) noexcept { return !(x < y); }
+    friend constexpr short operator<=>(uint x, uint y) noexcept { return (x < y) ? -1 : (y < x) ? 1 : 0; }
 
     friend constexpr uint operator~(uint x) noexcept { return {~x[0], ~x[1]}; }
     friend constexpr uint operator|(uint x, uint y) noexcept { return {x[0] | y[0], x[1] | y[1]}; }
@@ -1012,6 +1013,7 @@ public:
     friend constexpr bool operator>(const uint& x, const uint& y) noexcept { return y < x; }
     friend constexpr bool operator>=(const uint& x, const uint& y) noexcept { return !(x < y); }
     friend constexpr bool operator<=(const uint& x, const uint& y) noexcept { return !(y < x); }
+    friend constexpr short operator<=>(const uint& x, const uint&y) noexcept { return x < y ? -1 : x == y ? 0 : 1; }
 
     friend inline constexpr uint operator<<(const uint& x, uint64_t shift) noexcept
     {

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -7,9 +7,9 @@
 #include <algorithm>
 #include <array>
 #include <bit>
-#include <compare>
 #include <cassert>
 #include <climits>
+#include <compare>
 #include <concepts>
 #include <cstddef>
 #include <cstdint>

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -312,7 +312,7 @@ public:
     friend constexpr bool operator<=(uint x, uint y) noexcept { return !(y < x); }
     friend constexpr bool operator>(uint x, uint y) noexcept { return y < x; }
     friend constexpr bool operator>=(uint x, uint y) noexcept { return !(x < y); }
-    friend constexpr int8_t operator<=>(uint x, uint y) noexcept
+    friend constexpr int operator<=>(uint x, uint y) noexcept
     {
         return (x < y) ? -1 : (y < x) ? 1 : 0;
     }
@@ -1016,7 +1016,7 @@ public:
     friend constexpr bool operator>(const uint& x, const uint& y) noexcept { return y < x; }
     friend constexpr bool operator>=(const uint& x, const uint& y) noexcept { return !(x < y); }
     friend constexpr bool operator<=(const uint& x, const uint& y) noexcept { return !(y < x); }
-    friend constexpr int8_t operator<=>(const uint& x, const uint&y) noexcept
+    friend constexpr int operator<=>(const uint& x, const uint& y) noexcept
     {
         return x < y ? -1 : x == y ? 0 : 1;
     }

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -313,13 +313,10 @@ public:
 
     friend constexpr std::strong_ordering operator<=>(uint x, uint y) noexcept
     {
-        if (x < y)
-            return std::strong_ordering::less;
+        if (x == y)
+            return std::strong_ordering::equal;
 
-        if (x > y)
-            return std::strong_ordering::greater;
-
-        return std::strong_ordering::equal;
+        return (x < y) ? std::strong_ordering::less : std::strong_ordering::greater;
     }
 
     friend constexpr uint operator~(uint x) noexcept { return {~x[0], ~x[1]}; }

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <bit>
+#include <compare>
 #include <cassert>
 #include <climits>
 #include <concepts>
@@ -1035,13 +1036,10 @@ public:
 
     friend constexpr std::strong_ordering operator<=>(const uint& x, const uint& y) noexcept
     {
-        if (x < y)
-            return std::strong_ordering::less;
+        if (x == y)
+            return std::strong_ordering::equal;
 
-        if (x > y)
-            return std::strong_ordering::greater;
-
-        return std::strong_ordering::equal;
+        return (x < y) ? std::strong_ordering::less : std::strong_ordering::greater;
     }
 
     friend constexpr uint operator<<(const uint& x, uint64_t shift) noexcept

--- a/test/unittests/test_intx_api.cpp
+++ b/test/unittests/test_intx_api.cpp
@@ -269,9 +269,9 @@ struct Wrapper
 
 TYPED_TEST(uint_api, spaceship_operator_with_wrapper)
 {
-    Wrapper a{TypeParam{1}};
-    Wrapper b{TypeParam{2}};
-    Wrapper c{TypeParam{3}};
+    Wrapper<TypeParam> a{1};
+    Wrapper<TypeParam> b{2};
+    Wrapper<TypeParam> c{3};
 
     EXPECT_EQ(a <=> b, std::strong_ordering::less);
     EXPECT_EQ(a <=> a, std::strong_ordering::equal);

--- a/test/unittests/test_intx_api.cpp
+++ b/test/unittests/test_intx_api.cpp
@@ -259,35 +259,52 @@ TYPED_TEST(uint_api, comparison)
     EXPECT_TRUE(d >= x);
 }
 
+struct W
+{
+    intx::uint256 v;
+
+    friend auto operator<=>(W, W) = default;
+};
+
+struct W128
+{
+    intx::uint128 v;
+    friend auto operator<=>(W128, W128) = default;
+};
+
 TYPED_TEST(uint_api, spaceship_operator)
 {
-    auto a = uint256{1};
-    auto b = uint256{2};
-    auto c = uint256{3};
+    EXPECT_EQ(1, 1);
 
-    EXPECT_EQ(a <=> a, 0);
-    EXPECT_EQ(a <=> b, -1);
-    EXPECT_EQ(a <=> c, -1);
-    EXPECT_EQ(b <=> a, 1);
-    EXPECT_EQ(b <=> b, 0);
-    EXPECT_EQ(b <=> c, -1);
-    EXPECT_EQ(c <=> a, 1);
-    EXPECT_EQ(c <=> b, 1);
-    EXPECT_EQ(c <=> c, 0);
+    auto a = W{uint256{1}};
+    auto b = W{uint256{2}};
+    auto c = W{uint256{3}};
 
-    auto d = uint128{1};
-    auto e = uint128{2};
-    auto f = uint128{3};
+    EXPECT_EQ(a <=> b, std::strong_ordering::less);
+    EXPECT_EQ(a <=> a, std::strong_ordering::equal);
+    EXPECT_EQ(c <=> b, std::strong_ordering::greater);
 
-    EXPECT_EQ(d <=> d, 0);
-    EXPECT_EQ(d <=> e, -1);
-    EXPECT_EQ(e <=> d, 1);
-    EXPECT_EQ(d <=> f, -1);
-    EXPECT_EQ(f <=> d, 1);
-    EXPECT_EQ(e <=> e, 0);
-    EXPECT_EQ(e <=> f, -1);
-    EXPECT_EQ(f <=> e, 1);
-    EXPECT_EQ(f <=> f, 0);
+    EXPECT_TRUE(a < b);
+    EXPECT_TRUE(c > a);
+    EXPECT_TRUE(a >= a);
+    EXPECT_TRUE(b <= c);
+    EXPECT_TRUE(b == b);
+    EXPECT_TRUE(a != c);
+    
+    auto d = W128{uint128{1}};
+    auto e = W128{uint128{2}};
+    auto f = W128{uint128{3}};
+
+    EXPECT_EQ(d <=> e, std::strong_ordering::less);
+    EXPECT_EQ(f <=> f, std::strong_ordering::equal);
+    EXPECT_EQ(f <=> e, std::strong_ordering::greater);
+
+    EXPECT_TRUE(d < e);
+    EXPECT_TRUE(f > d);
+    EXPECT_TRUE(d >= d);
+    EXPECT_TRUE(e <= f);
+    EXPECT_TRUE(e == e);
+    EXPECT_TRUE(d != f);
 }
 
 TYPED_TEST(uint_api, arithmetic_op_assignment)

--- a/test/unittests/test_intx_api.cpp
+++ b/test/unittests/test_intx_api.cpp
@@ -269,9 +269,9 @@ struct Wrapper
 
 TYPED_TEST(uint_api, spaceship_operator_with_wrapper)
 {
-    auto a = Wrapper<TypeParam>{TypeParam{1}};
-    auto b = Wrapper<TypeParam>{TypeParam{2}};
-    auto c = Wrapper<TypeParam>{TypeParam{3}};
+    Wrapper a{TypeParam{1}};
+    Wrapper b{TypeParam{2}};
+    Wrapper c{TypeParam{3}};
 
     EXPECT_EQ(a <=> b, std::strong_ordering::less);
     EXPECT_EQ(a <=> a, std::strong_ordering::equal);
@@ -287,9 +287,9 @@ TYPED_TEST(uint_api, spaceship_operator_with_wrapper)
 
 TYPED_TEST(uint_api, spaceship_operator)
 {
-    auto a = TypeParam{1};
-    auto b = TypeParam{2};
-    auto c = TypeParam{3};
+    TypeParam a{1};
+    TypeParam b{2};
+    TypeParam c{3};
 
     EXPECT_EQ(a <=> a, std::strong_ordering::equal);
     EXPECT_EQ(a <=> b, std::strong_ordering::less);

--- a/test/unittests/test_intx_api.cpp
+++ b/test/unittests/test_intx_api.cpp
@@ -259,26 +259,19 @@ TYPED_TEST(uint_api, comparison)
     EXPECT_TRUE(d >= x);
 }
 
-struct W
+template <typename T>
+struct Wrapper
 {
-    intx::uint256 v;
+    T v;
 
-    friend auto operator<=>(W, W) = default;
+    friend auto operator<=>(Wrapper, Wrapper) = default;
 };
 
-struct W128
+TYPED_TEST(uint_api, spaceship_operator_with_wrapper)
 {
-    intx::uint128 v;
-    friend auto operator<=>(W128, W128) = default;
-};
-
-TYPED_TEST(uint_api, spaceship_operator)
-{
-    EXPECT_EQ(1, 1);
-
-    auto a = W{uint256{1}};
-    auto b = W{uint256{2}};
-    auto c = W{uint256{3}};
+    auto a = Wrapper<TypeParam>{TypeParam{1}};
+    auto b = Wrapper<TypeParam>{TypeParam{2}};
+    auto c = Wrapper<TypeParam>{TypeParam{3}};
 
     EXPECT_EQ(a <=> b, std::strong_ordering::less);
     EXPECT_EQ(a <=> a, std::strong_ordering::equal);
@@ -290,21 +283,23 @@ TYPED_TEST(uint_api, spaceship_operator)
     EXPECT_TRUE(b <= c);
     EXPECT_TRUE(b == b);
     EXPECT_TRUE(a != c);
+}
 
-    auto d = W128{uint128{1}};
-    auto e = W128{uint128{2}};
-    auto f = W128{uint128{3}};
+TYPED_TEST(uint_api, spaceship_operator)
+{
+    auto a = TypeParam{1};
+    auto b = TypeParam{2};
+    auto c = TypeParam{3};
 
-    EXPECT_EQ(d <=> e, std::strong_ordering::less);
-    EXPECT_EQ(f <=> f, std::strong_ordering::equal);
-    EXPECT_EQ(f <=> e, std::strong_ordering::greater);
-
-    EXPECT_TRUE(d < e);
-    EXPECT_TRUE(f > d);
-    EXPECT_TRUE(d >= d);
-    EXPECT_TRUE(e <= f);
-    EXPECT_TRUE(e == e);
-    EXPECT_TRUE(d != f);
+    EXPECT_EQ(a <=> a, std::strong_ordering::equal);
+    EXPECT_EQ(a <=> b, std::strong_ordering::less);
+    EXPECT_EQ(a <=> c, std::strong_ordering::less);
+    EXPECT_EQ(b <=> a, std::strong_ordering::greater);
+    EXPECT_EQ(b <=> b, std::strong_ordering::equal);
+    EXPECT_EQ(b <=> c, std::strong_ordering::less);
+    EXPECT_EQ(c <=> a, std::strong_ordering::greater);
+    EXPECT_EQ(c <=> b, std::strong_ordering::greater);
+    EXPECT_EQ(c <=> c, std::strong_ordering::equal);
 }
 
 TYPED_TEST(uint_api, arithmetic_op_assignment)

--- a/test/unittests/test_intx_api.cpp
+++ b/test/unittests/test_intx_api.cpp
@@ -259,6 +259,37 @@ TYPED_TEST(uint_api, comparison)
     EXPECT_TRUE(d >= x);
 }
 
+TYPED_TEST(uint_api, spaceship_operator)
+{
+    auto a = uint256{1};
+    auto b = uint256{2};
+    auto c = uint256{3};
+
+    EXPECT_EQ(a <=> a, 0);
+    EXPECT_EQ(a <=> b, -1);
+    EXPECT_EQ(a <=> c, -1);
+    EXPECT_EQ(b <=> a, 1);
+    EXPECT_EQ(b <=> b, 0);
+    EXPECT_EQ(b <=> c, -1);
+    EXPECT_EQ(c <=> a, 1);
+    EXPECT_EQ(c <=> b, 1);
+    EXPECT_EQ(c <=> c, 0);
+
+    auto d = uint128{1};
+    auto e = uint128{2};
+    auto f = uint128{3};
+
+    EXPECT_EQ(d <=> d, 0);
+    EXPECT_EQ(d <=> e, -1);
+    EXPECT_EQ(e <=> d, 1);
+    EXPECT_EQ(d <=> f, -1);
+    EXPECT_EQ(f <=> d, 1);
+    EXPECT_EQ(e <=> e, 0);
+    EXPECT_EQ(e <=> f, -1);
+    EXPECT_EQ(f <=> e, 1);
+    EXPECT_EQ(f <=> f, 0);
+}
+
 TYPED_TEST(uint_api, arithmetic_op_assignment)
 {
     auto x = TypeParam{};

--- a/test/unittests/test_intx_api.cpp
+++ b/test/unittests/test_intx_api.cpp
@@ -290,7 +290,7 @@ TYPED_TEST(uint_api, spaceship_operator)
     EXPECT_TRUE(b <= c);
     EXPECT_TRUE(b == b);
     EXPECT_TRUE(a != c);
-    
+
     auto d = W128{uint128{1}};
     auto e = W128{uint128{2}};
     auto f = W128{uint128{3}};


### PR DESCRIPTION
Extend `uint` types with support for three-way comparison operator (`<=>`).

Closes #295.