### PR TITLE
Remove whitespace in literal operator declarations

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1610,14 +1610,14 @@ constexpr uint256 mulmod(const uint256& x, const uint256& y, const uint256& mod)
 
 /// Define type alias uintN = uint<N> and the matching literal ""_uN.
 /// The literal operators are defined in the intx::literals namespace.
-#define DEFINE_ALIAS_AND_LITERAL(N)                   \
-    using uint##N = uint<N>;                          \
-    namespace literals                                \
-    {                                                 \
-    consteval uint##N operator"" _u##N(const char* s) \
-    {                                                 \
-        return from_string<uint##N>(s);               \
-    }                                                 \
+#define DEFINE_ALIAS_AND_LITERAL(N)                  \
+    using uint##N = uint<N>;                         \
+    namespace literals                               \
+    {                                                \
+    consteval uint##N operator""_u##N(const char* s) \
+    {                                                \
+        return from_string<uint##N>(s);              \
+    }                                                \
     }
 DEFINE_ALIAS_AND_LITERAL(128);
 DEFINE_ALIAS_AND_LITERAL(192);

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1608,13 +1608,16 @@ constexpr uint256 mulmod(const uint256& x, const uint256& y, const uint256& mod)
     return udivrem(umul(x, y), mod).rem;
 }
 
+#define INTX_JOIN2(X, Y) X##Y
+#define INTX_JOIN1(X, Y) INTX_JOIN2(X, Y)
+#define INTX_LITERAL(N) INTX_JOIN1(operator"", INTX_JOIN1(_u, N))
 /// Define type alias uintN = uint<N> and the matching literal ""_uN.
 /// The literal operators are defined in the intx::literals namespace.
 #define DEFINE_ALIAS_AND_LITERAL(N)                  \
     using uint##N = uint<N>;                         \
     namespace literals                               \
     {                                                \
-    consteval uint##N operator""_u##N(const char* s) \
+    consteval uint##N INTX_LITERAL(N)(const char* s) \
     {                                                \
         return from_string<uint##N>(s);              \
     }                                                \
@@ -1627,6 +1630,9 @@ DEFINE_ALIAS_AND_LITERAL(384);
 DEFINE_ALIAS_AND_LITERAL(448);
 DEFINE_ALIAS_AND_LITERAL(512);
 #undef DEFINE_ALIAS_AND_LITERAL
+#undef INTX_JOIN2
+#undef INTX_JOIN1
+#undef INTX_LITERAL
 
 using namespace literals;
 

--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1608,19 +1608,17 @@ constexpr uint256 mulmod(const uint256& x, const uint256& y, const uint256& mod)
     return udivrem(umul(x, y), mod).rem;
 }
 
-#define INTX_JOIN2(X, Y) X##Y
-#define INTX_JOIN1(X, Y) INTX_JOIN2(X, Y)
-#define INTX_LITERAL(N) INTX_JOIN1(operator"", INTX_JOIN1(_u, N))
+#define INTX_JOIN(X, Y) X##Y
 /// Define type alias uintN = uint<N> and the matching literal ""_uN.
 /// The literal operators are defined in the intx::literals namespace.
-#define DEFINE_ALIAS_AND_LITERAL(N)                  \
-    using uint##N = uint<N>;                         \
-    namespace literals                               \
-    {                                                \
-    consteval uint##N INTX_LITERAL(N)(const char* s) \
-    {                                                \
-        return from_string<uint##N>(s);              \
-    }                                                \
+#define DEFINE_ALIAS_AND_LITERAL(N)                               \
+    using uint##N = uint<N>;                                      \
+    namespace literals                                            \
+    {                                                             \
+    consteval uint##N INTX_JOIN(operator"", _u##N)(const char* s) \
+    {                                                             \
+        return from_string<uint##N>(s);                           \
+    }                                                             \
     }
 DEFINE_ALIAS_AND_LITERAL(128);
 DEFINE_ALIAS_AND_LITERAL(192);
@@ -1630,9 +1628,7 @@ DEFINE_ALIAS_AND_LITERAL(384);
 DEFINE_ALIAS_AND_LITERAL(448);
 DEFINE_ALIAS_AND_LITERAL(512);
 #undef DEFINE_ALIAS_AND_LITERAL
-#undef INTX_JOIN2
-#undef INTX_JOIN1
-#undef INTX_LITERAL
+#undef INTX_JOIN
 
 using namespace literals;
 


### PR DESCRIPTION
Fixes this warning from clang:
```
In file included from D:/src/test.cpp:6:
D:/src/intx/include/intx/intx.hpp:1622:1: warning: identifier '_u128' preceded by whitespace in a literal operator declaration is deprecated [-Wdeprecated-literal-operator]
 1622 | DEFINE_ALIAS_AND_LITERAL(128);
      | ^
D:/src/intx/include/intx/intx.hpp:1617:34: note: expanded from macro 'DEFINE_ALIAS_AND_LITERAL'
 1617 |     consteval uint##N operator"" _u##N(const char* s) \
      |                                  ^
<scratch space>:168:1: note: expanded from here
  168 | _u128
```