### PR TITLE
Don't specify deprecated float_denorm_style

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -732,8 +732,6 @@ struct numeric_limits<intx::uint<N>>  // NOLINT(cert-dcl58-cpp)
     static constexpr bool has_infinity = false;
     static constexpr bool has_quiet_NaN = false;
     static constexpr bool has_signaling_NaN = false;
-    static constexpr float_denorm_style has_denorm = denorm_absent;
-    static constexpr bool has_denorm_loss = false;
     static constexpr float_round_style round_style = round_toward_zero;
     static constexpr bool is_iec559 = false;
     static constexpr bool is_bounded = true;


### PR DESCRIPTION
In C++23 the `float_denorm_style`, `has_denorm` and `has_denorm_loss` of `std::numeric_limits` have been deprecated.

https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2614r2.pdf