### PR TITLE
Assume word counts out of div normalization are not negative

### DIFF
--- a/include/intx/intx.hpp
+++ b/include/intx/intx.hpp
@@ -1502,6 +1502,8 @@ template <unsigned M, unsigned N>
 constexpr div_result<uint<M>, uint<N>> udivrem(const uint<M>& u, const uint<N>& v) noexcept
 {
     auto na = internal::normalize(u, v);
+    INTX_REQUIRE(na.num_divisor_words > 0);
+    INTX_REQUIRE(na.num_numerator_words >= 0);
 
     if (na.num_numerator_words <= na.num_divisor_words)
         return {0, static_cast<uint<N>>(u)};


### PR DESCRIPTION
Add asserts/assumption statements to udivrem that the number of words in the argument out of normalization are not negative. This helps clang static analysis to avoid false positives.