### PR TITLE
test: Extract reciprocal_native()

### DIFF
--- a/test/benchmarks/bench_div.cpp
+++ b/test/benchmarks/bench_div.cpp
@@ -3,6 +3,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 #include <benchmark/benchmark.h>
+#include <experimental/div.hpp>
 #include <intx/intx.hpp>
 #include <test/utils/random.hpp>
 
@@ -54,26 +55,11 @@ void div_normalize(benchmark::State& state)
         benchmark::DoNotOptimize(x);
     }
 }
-BENCHMARK_TEMPLATE(div_normalize, internal::normalize);
+BENCHMARK(div_normalize<internal::normalize>);
 
 constexpr uint64_t neg(uint64_t x) noexcept
 {
     return ~x;
-}
-
-inline uint64_t reciprocal_naive(uint64_t d) noexcept
-{
-    const auto u = uint128{~uint64_t{0}, ~d};
-    uint64_t v{};
-
-#if __x86_64__
-    uint64_t _{};
-    asm("divq %4" : "=d"(_), "=a"(v) : "d"(u[1]), "a"(u[0]), "g"(d));  // NOLINT(hicpp-no-assembler)
-#else
-    v = (u / d)[0];
-#endif
-
-    return v;
 }
 
 template <typename T, uint64_t Fn(T)>

--- a/test/experimental/CMakeLists.txt
+++ b/test/experimental/CMakeLists.txt
@@ -2,8 +2,15 @@
 # Copyright 2019 Pawel Bylica.
 # Licensed under the Apache License, Version 2.0.
 
-add_library(experimental STATIC add.cpp add.hpp addmod.hpp)
+add_library(experimental STATIC)
+add_library(intx::experimental ALIAS experimental)
 target_compile_definitions(experimental PRIVATE INTX_EXPERIMENTAL)
 target_include_directories(experimental PUBLIC ${PROJECT_SOURCE_DIR}/test)
 target_link_libraries(experimental PUBLIC intx::intx)
-add_library(intx::experimental ALIAS experimental)
+target_sources(
+    experimental PRIVATE
+    add.cpp
+    add.hpp
+    addmod.hpp
+    div.hpp
+)

--- a/test/experimental/div.hpp
+++ b/test/experimental/div.hpp
@@ -1,0 +1,21 @@
+
+#pragma once
+#include <intx/intx.hpp>
+
+namespace intx
+{
+inline uint64_t reciprocal_naive(uint64_t d) noexcept
+{
+    const auto u = uint128{~uint64_t{0}, ~d};
+    uint64_t v{};
+
+#if __x86_64__
+    uint64_t _{};
+    asm("divq %4" : "=d"(_), "=a"(v) : "d"(u[1]), "a"(u[0]), "g"(d));  // NOLINT(hicpp-no-assembler)
+#else
+    v = (u / d)[0];
+#endif
+
+    return v;
+}
+}  // namespace intx

--- a/test/unittests/test_div.cpp
+++ b/test/unittests/test_div.cpp
@@ -2,6 +2,7 @@
 // Copyright 2019-2020 Pawel Bylica.
 // Licensed under the Apache License, Version 2.0.
 
+#include <experimental/div.hpp>
 #include <gtest/gtest.h>
 #include <intx/intx.hpp>
 
@@ -430,21 +431,6 @@ TEST(div, sdivrem_512)
     EXPECT_EQ(sdivrem(-n, d).rem, -1_u512);
     EXPECT_EQ(sdivrem(n, -d).quot, -4_u512);
     EXPECT_EQ(sdivrem(n, -d).rem, 1_u512);
-}
-
-inline uint64_t reciprocal_naive(uint64_t d) noexcept
-{
-    const auto u = uint128{~uint64_t{0}, ~d};
-    uint64_t v{};
-
-#if __x86_64__
-    uint64_t _{};
-    asm("divq %4" : "=d"(_), "=a"(v) : "d"(u[1]), "a"(u[0]), "g"(d));  // NOLINT(hicpp-no-assembler)
-#else
-    v = (u / d)[0];
-#endif
-
-    return v;
 }
 
 TEST(div, reciprocal)


### PR DESCRIPTION
Merge two copies of `reciprocal_native()` into single inline function used by both benchmarks and unit tests.